### PR TITLE
perf: bundle all deps, reduce install size 31x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 While `rdrr` is pre-`1.0`, minor version bumps (`0.x.0`) may contain breaking changes.
 
+## [0.2.1] — 2026-04-16
+
+### Changed
+
+- Bundle all runtime dependencies (turndown, linkedom, commander) into dist -- zero production dependencies.
+- Replace `@mixmark-io/domino` (7.4 MB) with a lightweight linkedom-based shim.
+- Enable full minification.
+- Install size reduced from 12.6 MB to 405 KB (31x).
+
 ## [0.2.0] — 2026-04-14
 
 First public release.
@@ -36,4 +45,5 @@ First public release.
 - Requires Node.js >=20.17.0.
 - API is considered experimental until `1.0.0`; breaking changes may land in `0.x.0` releases.
 
+[0.2.1]: https://github.com/fkonovalov/rdrr/releases/tag/v0.2.1
 [0.2.0]: https://github.com/fkonovalov/rdrr/releases/tag/v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdrr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "description": "Convert any URL to clean markdown for AI agents.",
   "keywords": [
@@ -66,14 +66,11 @@
     "fmt": "oxfmt --write .",
     "prepublishOnly": "pnpm build"
   },
-  "dependencies": {
-    "commander": "14.0.3",
-    "linkedom": "0.18.12",
-    "turndown": "7.2.4"
-  },
   "devDependencies": {
     "@types/node": "22.15.3",
-    "@types/turndown": "5.0.5",
+    "commander": "14.0.3",
+    "linkedom": "0.18.12",
+    "turndown": "7.2.4",
     "knip": "6.4.0",
     "oxfmt": "0.44.0",
     "oxlint": "1.59.0",

--- a/src/domino-shim.ts
+++ b/src/domino-shim.ts
@@ -1,0 +1,3 @@
+import { parseHTML } from "linkedom"
+
+export const createDocument = (html: string) => parseHTML(html).document

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "tsdown"
 
 const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8")) as { version: string }
@@ -8,12 +9,18 @@ export default defineConfig({
   target: "es2022",
   format: ["esm"],
   platform: "node",
-  minify: "dce-only",
+  minify: true,
   sourcemap: false,
   hash: false,
   dts: true,
   clean: true,
   define: {
     __RDRR_VERSION__: JSON.stringify(pkg.version),
+  },
+  alias: {
+    "@mixmark-io/domino": fileURLToPath(new URL("./src/domino-shim.ts", import.meta.url)),
+  },
+  deps: {
+    alwaysBundle: ["turndown", "linkedom", "commander"],
   },
 })


### PR DESCRIPTION
## Summary
- Bundle turndown, linkedom, and commander into dist via tsdown `alwaysBundle`
- Replace `@mixmark-io/domino` (7.4 MB) with a 3-line linkedom-based shim
- Move all runtime deps to devDependencies (zero production dependencies)
- Enable full minification

**Install size: 12.6 MB → 405 KB (31x reduction)**

## What changed
| | Before | After |
|---|---|---|
| Install size | 12.6 MB | 405 KB |
| Production deps | 15 packages | 0 |
| dist size | 328 KB | 405 KB |

Root cause: `turndown` pulled in `@mixmark-io/domino` (7.4 MB) — a full DOM implementation — even though `linkedom` was already available. Bundling everything and aliasing domino to a tiny linkedom shim eliminates all transitive dependency weight.

No API or behavior changes. All 22 tests pass.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` — 22/22 pass
- [x] `pnpm lint` — 0 errors
- [x] CLI works: `rdrr https://example.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)