### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 While `rdrr` is pre-`1.0`, minor version bumps (`0.x.0`) may contain breaking changes.
 
+## [0.4.0] — 2026-04-18
+
+The "make rdrr a first-class tool for AI agents" release.
+
+### Added
+
+- **Single X posts.** `rdrr https://x.com/…/status/…` now goes straight to fxtwitter, with a twimg-syndication fallback if that's down. No more login walls, no HTML fetch at all.
+- **`--budget <tokens>`.** Fit the output into a token budget. Cuts at paragraph boundaries, never inside a fenced code block, always keeps the head so truncation never leaves an empty page.
+- **`--quality`.** A readability score (0–100) with signals — links, paragraphs, boilerplate, paywall markers in five languages. Lets agents route low-confidence pages to a fallback instead of handing an LLM garbage.
+- **`--format md|json|jsonl|xml`.** JSONL for batch pipelines, XML with a real `<?xml?>` declaration and CDATA-safe body for LLMs that parse XML better than markdown. `-j` still works.
+- **`-c, --clip`.** Cross-platform clipboard: pbcopy, wl-copy, xclip, xsel, clip.exe.
+- **`rdrr history` and `rdrr last`.** A local JSONL log of every fetch, auto-rotated at 1000 entries. `--no-history` or `RDRR_NO_HISTORY=1` to opt out.
+
+### Fixed
+
+- **The bundled CLI was quietly missing every site extractor** (reddit, hackernews, substack, x-oembed, chatgpt, claude, grok, gemini, github, …). A `sideEffects` whitelist in `package.json` was tree-shaking the registration calls out of the published build, leaving only generic readability. Restored.
+- **`extract` / `extractAsync` now respect `options.markdown: true`.** Browser-extension callers were getting raw HTML back on Wikipedia "no article" pages.
+
+### Security
+
+- URLs logged to `history.jsonl` are stripped of basic-auth credentials **and** of any `api_key` / `token` / `authorization` / `secret` query parameters.
+- CLI arg-value logging redacts sensitive flags (`--github-token`, `--user-agent`, `-l`).
+- XML CDATA wrapping splits any stray `]]>` in article content so a single tweet can't prematurely close the block.
+
+### Internal
+
+- fxtwitter normalisation (facets, media, quotes) lives in one shared module instead of three forks.
+
 ## [0.3.0] — 2026-04-17
 
 ### Added
@@ -83,6 +111,7 @@ First public release.
 - Requires Node.js >=20.17.0.
 - API is considered experimental until `1.0.0`; breaking changes may land in `0.x.0` releases.
 
+[0.4.0]: https://github.com/fkonovalov/rdrr/releases/tag/v0.4.0
 [0.3.0]: https://github.com/fkonovalov/rdrr/releases/tag/v0.3.0
 [0.2.2]: https://github.com/fkonovalov/rdrr/releases/tag/v0.2.2
 [0.2.1]: https://github.com/fkonovalov/rdrr/releases/tag/v0.2.1

--- a/README.md
+++ b/README.md
@@ -41,11 +41,23 @@ rdrr https://github.com/mozilla/readability/issues/1
 # X timeline
 rdrr https://x.com/discotune -n 10
 
+# Single X post (direct API, bypasses login walls)
+rdrr https://x.com/discotune/status/2045444995768078376
+
 # Save to file
 rdrr https://example.com -o article.md
 
-# JSON with metadata
-rdrr https://example.com --json
+# Copy to clipboard
+rdrr https://example.com --clip
+
+# Fit a 2k-token budget for LLM context
+rdrr https://some.article.example/long-read --budget 2000
+
+# LLM-friendly XML with quality score
+rdrr https://react.dev/learn --format xml --quality
+
+# List recent fetches
+rdrr history --limit 10
 ```
 
 ### Library
@@ -66,14 +78,28 @@ result.siteName    // "Wikipedia"
 | Flag | Description |
 | --- | --- |
 | `-o, --output <file>` | Save to file instead of stdout |
-| `-j, --json` | Full JSON with metadata |
+| `-c, --clip` | Copy output to the system clipboard (suppresses stdout) |
+| `-j, --json` | Full JSON with metadata (alias for `--format json`) |
+| `--format <fmt>` | Output format: `md` (default), `json`, `jsonl`, or `xml` |
 | `-p, --property <name>` | Extract a single field (`title`, `content`, ...) |
 | `-l, --language <code>` | Preferred language (BCP 47) |
 | `-n, --limit <n>` | Max items for aggregate URLs (default: `10`) |
 | `--order <order>` | `newest` (default) or `oldest` |
+| `--budget <tokens>` | Truncate body at a paragraph boundary to fit a token budget |
+| `--quality` | Attach a readability score (0-100) + signals to JSON output |
 | `--check` | Probe if URL is readable (exit 0/1) |
 | `--llms` | Append site's `/llms.txt` |
+| `--no-history` | Skip logging this call to history |
 | `--debug` | Pipeline diagnostics to stderr |
+
+### Subcommands
+
+```sh
+rdrr history [--limit 20] [--search react] [--since 2026-04-01] [--json]
+rdrr last [--json]
+```
+
+History lives at `$XDG_STATE_HOME/rdrr/history.jsonl` (falls back to `~/.local/state/rdrr/history.jsonl`), auto-rotates at 1000 entries, and strips basic-auth credentials before writing. Disable globally with `RDRR_NO_HISTORY=1`.
 
 ## API
 
@@ -88,7 +114,7 @@ const result = await parse(url, {
 })
 ```
 
-Returns a `ParseResult` with `type`, `title`, `author`, `content`, `description`, `domain`, `siteName`, `published`, `wordCount`, `readTime`, and more. The result is narrowed by `type`: `"webpage"`, `"youtube"`, `"github"`, `"pdf"`, or `"x-profile"`.
+Returns a `ParseResult` with `type`, `title`, `author`, `content`, `description`, `domain`, `siteName`, `published`, `wordCount`, `readTime`, and more. The result is narrowed by `type`: `"webpage"`, `"youtube"`, `"github"`, `"pdf"`, `"x-profile"`, or `"x-status"`.
 
 ### `parseHtml(html, options?)`
 
@@ -116,13 +142,13 @@ Also available as direct imports: `parseWeb`, `parseYouTube`, `parseGitHub`, `pa
 
 ## Supported sources
 
-| Type | What it handles |
-| --- | --- |
-| **Webpages** | Any HTML page with 20+ site-specific extractors |
-| **YouTube** | Transcripts with chapters, speakers, timestamps |
-| **GitHub** | Issues, PRs (with comments), raw files |
-| **PDFs** | Any public `.pdf` (requires optional `unpdf`) |
-| **X/Twitter** | Single posts and full profile timelines |
+| Type | What it handles                                     |
+| --- |-----------------------------------------------------|
+| **Webpages** | Any HTML page with 20+ site-specific extractors     |
+| **YouTube** | Transcripts with chapters, speakers, timestamps     |
+| **GitHub** | Issues, PRs (with comments), raw files              |
+| **PDFs** | Any public `.pdf` (requires optional `unpdf`)       |
+| **X/Twitter** | Single posts and full profile timelines             |
 | **llms.txt** | Appended on demand via `--llms` or `includeLlmsTxt` |
 
 ## Community

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdrr",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "Convert any URL to clean markdown for AI agents.",
   "keywords": [
@@ -42,7 +42,9 @@
   "type": "module",
   "sideEffects": [
     "./dist/parse-html.mjs",
-    "./dist/esm.mjs"
+    "./dist/esm.mjs",
+    "./src/extract/sites/init.ts",
+    "./src/extract/sites/*.ts"
   ],
   "types": "./dist/index.d.mts",
   "typesVersions": {

--- a/src/__tests__/detect.test.ts
+++ b/src/__tests__/detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { detectUrlType, extractVideoId, extractXHandle, isValidUrl, normalizeUrl } from "../detect"
+import { detectUrlType, extractVideoId, extractXHandle, extractXStatus, isValidUrl, normalizeUrl } from "../detect"
 
 describe("detectUrlType", () => {
   it("classifies youtube variants", () => {
@@ -31,12 +31,41 @@ describe("detectUrlType", () => {
   it("does not classify x reserved paths as profile", () => {
     expect(detectUrlType("https://x.com/home")).toBe("webpage")
     expect(detectUrlType("https://x.com/settings")).toBe("webpage")
-    expect(detectUrlType("https://x.com/i/status/123")).toBe("webpage")
+  })
+
+  it("classifies x/twitter status urls", () => {
+    expect(detectUrlType("https://x.com/someone/status/123")).toBe("x-status")
+    expect(detectUrlType("https://twitter.com/handle/status/9876")).toBe("x-status")
+    // Routed-by-id form with `i` placeholder for unknown author.
+    expect(detectUrlType("https://x.com/i/status/123")).toBe("x-status")
   })
 
   it("falls back to webpage for anything else", () => {
     expect(detectUrlType("https://example.com")).toBe("webpage")
     expect(detectUrlType("https://react.dev/learn")).toBe("webpage")
+  })
+})
+
+describe("extractXStatus", () => {
+  it("extracts handle + id", () => {
+    expect(extractXStatus("https://x.com/someone/status/123")).toEqual({ handle: "someone", id: "123" })
+    expect(extractXStatus("https://twitter.com/handle/status/987654321")).toEqual({
+      handle: "handle",
+      id: "987654321",
+    })
+  })
+
+  it("supports the /i/status/ canonical form", () => {
+    expect(extractXStatus("https://x.com/i/status/123")).toEqual({ handle: null, id: "123" })
+  })
+
+  it("returns null for non-status paths", () => {
+    expect(extractXStatus("https://x.com/someone")).toBeNull()
+    expect(extractXStatus("https://x.com/i/foo/123")).toBeNull()
+  })
+
+  it("returns null for non-x hosts", () => {
+    expect(extractXStatus("https://example.com/someone/status/1")).toBeNull()
   })
 })
 

--- a/src/__tests__/shared.test.ts
+++ b/src/__tests__/shared.test.ts
@@ -110,6 +110,15 @@ describe("ensureProtocol", () => {
     expect(ensureProtocol("example.com")).toBe("https://example.com")
     expect(ensureProtocol("example.com/path?q=1")).toBe("https://example.com/path?q=1")
   })
+
+  it("leaves other schemes alone (so the caller can reject them later)", () => {
+    // Regression: an earlier check only spotted http/https, so `ftp://foo`
+    // got rewritten to `https://ftp://foo` and slipped past URL validation.
+    expect(ensureProtocol("ftp://example.com")).toBe("ftp://example.com")
+    expect(ensureProtocol("mailto:a@b.com")).toBe("mailto:a@b.com")
+    expect(ensureProtocol("file:///etc/hosts")).toBe("file:///etc/hosts")
+    expect(ensureProtocol("javascript:alert(1)")).toBe("javascript:alert(1)")
+  })
 })
 
 describe("mergeSignals", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,11 @@ import { resolve as resolvePath } from "node:path"
 import { text as readStdinText } from "node:stream/consumers"
 import { pathToFileURL } from "node:url"
 import type { ParseResult } from "./types"
+import { estimateTokens, truncateToBudget } from "./cli/budget"
+import { copyToClipboard } from "./cli/clipboard"
+import { parseFormat, renderJsonl, renderXml, type EnrichedResult, type OutputFormat } from "./cli/format"
+import { filterHistory, readHistory, recordHistory, sanitiseArgs, sanitiseUrl } from "./cli/history"
+import { computeQuality } from "./cli/quality"
 import { detectUrlType } from "./detect"
 import { isProbablyReaderable } from "./extract/readerable"
 import { parseHtml } from "./provider/web"
@@ -93,6 +98,14 @@ const parseOrderArg = (value: string): "newest" | "oldest" => {
   return value
 }
 
+const parseFormatArg = (value: string): OutputFormat => {
+  try {
+    return parseFormat(value)
+  } catch {
+    throw new InvalidArgumentError("must be one of md | json | jsonl | xml")
+  }
+}
+
 const program = new Command()
 
 program
@@ -101,7 +114,9 @@ program
   .version(__RDRR_VERSION__)
   .argument("<input>", "URL, local .html file, or - to read HTML from stdin")
   .option("-o, --output <file>", "save to file instead of stdout")
-  .option("-j, --json", "output full JSON with metadata")
+  .option("-c, --clip", "copy output to the system clipboard (suppresses stdout)")
+  .option("-j, --json", "output full JSON with metadata (alias for --format json)")
+  .option("--format <fmt>", "output format: md | json | jsonl | xml", parseFormatArg)
   .option("-p, --property <name>", "extract specific field (title, author, etc.)")
   .option("-l, --language <code>", "preferred language (BCP 47)")
   .option("-n, --limit <n>", "for aggregate URLs (e.g. x.com profiles): max items to fetch", parseLimitArg)
@@ -112,6 +127,9 @@ program
   .option("--user-agent <ua>", "override the outbound User-Agent header")
   .option("--github-token <token>", "GitHub API token (falls back to $GITHUB_TOKEN)")
   .option("--wpm <n>", "words-per-minute used for readTime estimation (default 200)", parseLimitArg)
+  .option("--budget <tokens>", "truncate output to fit a token budget", parseLimitArg)
+  .option("--quality", "include a quality/readability report (score 0-100) in JSON output")
+  .option("--no-history", "skip logging this call to ~/.local/state/rdrr/history.jsonl")
   .option("--allow-private-networks", "allow fetches against RFC1918/loopback/link-local (SSRF-unsafe)")
   .option("--debug", "print pipeline diagnostics to stderr")
   .action(
@@ -119,7 +137,9 @@ program
       input: string,
       opts: {
         output?: string
+        clip?: boolean
         json?: boolean
+        format?: OutputFormat
         property?: string
         language?: string
         limit?: number
@@ -130,6 +150,9 @@ program
         userAgent?: string
         githubToken?: string
         wpm?: number
+        budget?: number
+        quality?: boolean
+        history?: boolean
         allowPrivateNetworks?: boolean
         debug?: boolean
       },
@@ -163,16 +186,47 @@ program
           contentChars: result.content.length,
         })
 
-        const output = formatOutput(result, source, opts)
+        const budgeted: EnrichedResult = opts.budget ? applyBudget(result, opts.budget) : result
+        if (opts.budget) debug("budget", { budget: opts.budget, contentChars: budgeted.content.length })
+
+        const scored: EnrichedResult = opts.quality ? { ...budgeted, quality: computeQuality(budgeted) } : budgeted
+        if (scored.quality) debug("quality", scored.quality)
+
+        const output = formatOutput(scored, source, opts)
 
         if (opts.output) {
           writeFileSync(opts.output, output, "utf-8")
           process.stderr.write(`Saved to ${opts.output}\n`)
-        } else {
+        }
+        if (opts.clip) {
+          try {
+            const backend = await copyToClipboard(output)
+            process.stderr.write(`Copied ${output.length} chars to clipboard (${backend})\n`)
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err)
+            process.stderr.write(`Clipboard copy failed: ${message}\n`)
+            process.exit(5)
+          }
+        }
+        if (!opts.output && !opts.clip) {
           process.stdout.write(output)
         }
 
-        debug("done", { ms: Date.now() - started })
+        const durationMs = Date.now() - started
+        if (resolved.kind === "url" && opts.history !== false) {
+          const cleanArgs = sanitiseArgs(process.argv.slice(2).filter((a) => a !== resolved.raw))
+          recordHistory({
+            ts: new Date().toISOString(),
+            url: sanitiseUrl(resolved.url!),
+            title: scored.title,
+            tokens: estimateTokens(output),
+            ...(scored.quality ? { quality: scored.quality.score } : {}),
+            durationMs,
+            args: cleanArgs,
+          })
+        }
+
+        debug("done", { ms: durationMs })
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         process.stderr.write(`Error: ${message}\n`)
@@ -221,6 +275,14 @@ const runPipeline = async (
   return parseHtml(resolved.html!, { url: resolved.url, language: opts.language, wordsPerMinute: opts.wpm })
 }
 
+const applyBudget = (result: ParseResult, budget: number): EnrichedResult => {
+  const { content, info } = truncateToBudget(result.content, budget)
+  if (!info) return result
+  // Attach `truncated` as an extra field so JSON output carries it; frontmatter/
+  // markdown modes get the inline `[truncated ...]` marker that `content` already includes.
+  return { ...result, content, truncated: info }
+}
+
 const pickProperty = (result: ParseResult, property: string): unknown => {
   // `ParseResult` variants (YouTube, PDF, GitHub, XProfile) each add their own
   // fields. Route through a discriminated index instead of a blanket cast so
@@ -229,9 +291,11 @@ const pickProperty = (result: ParseResult, property: string): unknown => {
   return Object.hasOwn(record, property) ? record[property] : undefined
 }
 
-const formatOutput = (result: ParseResult, source: string, opts: { json?: boolean; property?: string }): string => {
-  if (opts.json) return JSON.stringify(result, null, 2)
-
+const formatOutput = (
+  result: EnrichedResult,
+  source: string,
+  opts: { json?: boolean; format?: OutputFormat; property?: string },
+): string => {
   if (opts.property) {
     const value = pickProperty(result, opts.property)
     if (value === undefined) {
@@ -241,7 +305,87 @@ const formatOutput = (result: ParseResult, source: string, opts: { json?: boolea
     return typeof value === "string" ? value : JSON.stringify(value, null, 2)
   }
 
-  return buildFrontmatter(result, source) + result.content
+  const format = resolveFormat(opts)
+  switch (format) {
+    case "json":
+      return JSON.stringify(result, null, 2)
+    case "jsonl":
+      return renderJsonl(result)
+    case "xml":
+      return renderXml(result, { source, fetchedAt: new Date().toISOString() })
+    case "md":
+    default:
+      return buildFrontmatter(result, source) + result.content
+  }
 }
+
+const resolveFormat = (opts: { json?: boolean; format?: OutputFormat }): OutputFormat => {
+  // `-j`/`--json` and `--format` together are ambiguous. Warn so scripted
+  // callers see the collision, then fall back to `--format` (explicit beats
+  // legacy) — keeps modern usage predictable without breaking `-j`-only
+  // scripts.
+  if (opts.json && opts.format && opts.format !== "json") {
+    process.stderr.write(
+      `Warning: both --json and --format ${opts.format} given; using --format ${opts.format}\n`,
+    )
+    return opts.format
+  }
+  if (opts.json) return "json"
+  return opts.format ?? "md"
+}
+
+// commander 14 leaks parent-defined flag names into subcommand action's opts
+// object (they're accessible via `optsWithGlobals()` only). We standardise on
+// `optsWithGlobals()` here so subcommand flags that collide with parent flags
+// (like `--json`) still work.
+interface CommandSelf {
+  optsWithGlobals: () => Record<string, unknown>
+}
+
+program
+  .command("history")
+  .description("list recent rdrr fetches")
+  .option("--json", "emit raw JSONL")
+  .option("--limit <n>", "max entries to show (default 20)", parseLimitArg)
+  .option("--search <q>", "substring match on title/url")
+  .option("--since <date>", "only entries at or after this ISO date")
+  .action(function (this: CommandSelf) {
+    const opts = this.optsWithGlobals() as { json?: boolean; limit?: number; search?: string; since?: string }
+    const since = opts.since ? new Date(opts.since) : undefined
+    if (since && Number.isNaN(since.getTime())) {
+      process.stderr.write(`Invalid --since date: ${opts.since}\n`)
+      process.exit(2)
+    }
+    const entries = filterHistory(readHistory(), { limit: opts.limit ?? 20, search: opts.search, since })
+    if (entries.length === 0) {
+      process.stderr.write("no history yet\n")
+      return
+    }
+    if (opts.json) {
+      for (const e of entries) process.stdout.write(JSON.stringify(e) + "\n")
+      return
+    }
+    for (const e of entries) {
+      const ts = e.ts.replace("T", " ").slice(0, 19)
+      const tokens = String(e.tokens).padStart(6)
+      process.stdout.write(`${ts}  ${tokens}t  ${e.title || "(untitled)"} — ${e.url}\n`)
+    }
+  })
+
+program
+  .command("last")
+  .description("print the most recent rdrr fetch")
+  .option("-j, --json", "full last-entry JSON")
+  .action(function (this: CommandSelf) {
+    const opts = this.optsWithGlobals() as { json?: boolean }
+    const entries = readHistory()
+    const latest = entries[entries.length - 1]
+    if (!latest) {
+      process.stderr.write("no history yet\n")
+      process.exit(1)
+    }
+    if (opts.json) process.stdout.write(JSON.stringify(latest, null, 2) + "\n")
+    else process.stdout.write(latest.url + "\n")
+  })
 
 program.parse()

--- a/src/cli/__tests__/budget.test.ts
+++ b/src/cli/__tests__/budget.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { estimateTokens, truncateToBudget } from "../budget"
+
+describe("estimateTokens", () => {
+  it("uses the documented 4-char-per-token ratio", () => {
+    expect(estimateTokens("")).toBe(0)
+    expect(estimateTokens("abcd")).toBe(1)
+    expect(estimateTokens("abcde")).toBe(2)
+  })
+})
+
+describe("truncateToBudget", () => {
+  const sample = Array.from({ length: 6 }, (_, i) => `Paragraph ${i + 1}. ${"x".repeat(40)}`).join("\n\n")
+
+  it("returns content unchanged when under budget", () => {
+    const result = truncateToBudget(sample, 10_000)
+    expect(result.content).toBe(sample)
+    expect(result.info).toBeNull()
+  })
+
+  it("cuts at paragraph boundaries and appends a marker", () => {
+    const result = truncateToBudget(sample, 40)
+    expect(result.info).not.toBeNull()
+    expect(result.info!.omittedTokens).toBeGreaterThan(0)
+    // Marker line has the exact `[truncated X tokens, Y total]` shape.
+    expect(result.content).toMatch(/\[truncated \d+ tokens, \d+ total\]$/)
+    // Nothing should be cut in the middle of a paragraph.
+    expect(result.content.split("\n\n").filter((p) => p.startsWith("Paragraph")).length).toBeLessThan(6)
+  })
+
+  it("still reports totals when the budget is smaller than a single paragraph", () => {
+    const result = truncateToBudget(sample, 1)
+    // Head-preservation: we always keep the first paragraph so the caller has context,
+    // even when the budget is too small for anything else.
+    expect(result.info!.kept).toBe(1)
+    expect(result.content).toContain("Paragraph 1")
+    expect(result.content).toContain("[truncated")
+  })
+
+  it("does not append a misleading marker when head-preservation already kept everything", () => {
+    // Single-paragraph content that exceeds the budget: kept === total, so
+    // truncation never actually happened. The output must match the input
+    // exactly — no `[truncated 0 tokens, N total]` lie.
+    const single = "one long paragraph with enough text to exceed any tiny budget we throw at it ".repeat(3)
+    const result = truncateToBudget(single, 5)
+    expect(result.info).toBeNull()
+    expect(result.content).toBe(single)
+    expect(result.content).not.toContain("[truncated")
+  })
+
+  it("closes dangling fenced code blocks when a cut lands mid-block", () => {
+    // Content that opens a fenced block in one paragraph and closes it much
+    // later, separated by another fence-only paragraph that pushes us past the
+    // budget if the first paragraph is small enough to be kept on its own.
+    const content = [
+      "```js",
+      "const a = 1",
+      "```",
+      "More prose that will be dropped.",
+      "```ts",
+      "const b = 2",
+      "```",
+    ].join("\n\n")
+    const result = truncateToBudget(content, 4)
+    // Every opening fence in the kept output must have a matching closing one.
+    const fences = result.content.match(/^```/gm) ?? []
+    expect(fences.length % 2).toBe(0)
+  })
+})

--- a/src/cli/__tests__/format.test.ts
+++ b/src/cli/__tests__/format.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import type { ParseResult } from "../../types"
+import { parseFormat, renderJsonl, renderXml } from "../format"
+
+const sample: ParseResult = {
+  type: "webpage",
+  title: "Example <x>",
+  author: "Alice",
+  content: "# Heading\n\nBody paragraph with [link](https://example.com).",
+  description: "Short description",
+  domain: "example.com",
+  siteName: "Example",
+  language: "en",
+  published: "2026-04-18",
+  wordCount: 42,
+  readTime: "1 min",
+}
+
+describe("parseFormat", () => {
+  it("accepts every documented value", () => {
+    expect(parseFormat("md")).toBe("md")
+    expect(parseFormat("json")).toBe("json")
+    expect(parseFormat("jsonl")).toBe("jsonl")
+    expect(parseFormat("xml")).toBe("xml")
+  })
+
+  it("rejects unknown values", () => {
+    expect(() => parseFormat("yaml")).toThrow(/Unsupported format/)
+  })
+})
+
+describe("renderJsonl", () => {
+  it("emits one line per record", () => {
+    const out = renderJsonl(sample)
+    expect(out.endsWith("\n")).toBe(true)
+    expect(out.split("\n").filter(Boolean)).toHaveLength(1)
+    expect(JSON.parse(out.trim()).title).toBe("Example <x>")
+  })
+
+  it("handles arrays", () => {
+    const out = renderJsonl([sample, sample])
+    expect(out.trim().split("\n")).toHaveLength(2)
+  })
+})
+
+describe("renderXml", () => {
+  it("escapes metadata and CDATA-wraps the body", () => {
+    const out = renderXml(sample, { source: "https://example.com", fetchedAt: "2026-04-18T00:00:00Z" })
+    expect(out).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/)
+    expect(out).toContain("<article ")
+    expect(out).toContain("<title>Example &lt;x&gt;</title>")
+    expect(out).toContain("<![CDATA[# Heading")
+    expect(out.trim().endsWith("</article>")).toBe(true)
+  })
+
+  it("emits <quality> and <truncated> elements when the enriched fields are present", () => {
+    const enriched = {
+      ...sample,
+      quality: { score: 87, verdict: "good" as const },
+      truncated: { omittedTokens: 10, totalTokens: 100, kept: 2, total: 5 },
+    }
+    const out = renderXml(enriched, { source: "https://example.com", fetchedAt: "2026-04-18T00:00:00Z" })
+    expect(out).toContain('<quality score="87" verdict="good"/>')
+    expect(out).toContain('<truncated omittedTokens="10" totalTokens="100"/>')
+  })
+
+  it("splits a stray ]]> inside content so a CDATA block never closes early", () => {
+    const hostile = { ...sample, content: "before ]]> after" }
+    const out = renderXml(hostile, { source: "https://x", fetchedAt: "2026-04-18T00:00:00Z" })
+    // Original `]]>` is rewritten as `]]]]><![CDATA[>` so that when concatenated
+    // with the wrapping CDATA tags, no single `]]>` sits inside an open section.
+    expect(out).toContain("]]]]><![CDATA[>")
+    expect(out).not.toContain("before ]]> after")
+    // The body should still round-trip to the expected logical text.
+    const match = out.match(/<content>(.*)<\/content>/s)
+    const cdataContent = match![1]!.replace(/]]]]><!\[CDATA\[>/g, "]]>").replace(/^<!\[CDATA\[/, "").replace(/]]>$/, "")
+    expect(cdataContent).toBe("before ]]> after")
+  })
+})

--- a/src/cli/__tests__/history.test.ts
+++ b/src/cli/__tests__/history.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { filterHistory, historyPath, readHistory, recordHistory, sanitiseArgs, sanitiseUrl } from "../history"
+
+describe("sanitiseUrl", () => {
+  it("strips basic-auth credentials", () => {
+    expect(sanitiseUrl("https://user:pass@example.com/path")).toBe("https://example.com/path")
+  })
+
+  it("redacts values of common secret-bearing query parameters", () => {
+    const out = sanitiseUrl("https://api.example.com/items?api_key=secret123&q=hello")
+    expect(out).toContain("api_key=REDACTED")
+    expect(out).toContain("q=hello")
+    expect(out).not.toContain("secret123")
+  })
+
+  it("redacts case-insensitively (Authorization, TOKEN)", () => {
+    const out = sanitiseUrl("https://x/?Authorization=bearer+xxx&TOKEN=abc")
+    expect(out).toContain("Authorization=REDACTED")
+    expect(out).toContain("TOKEN=REDACTED")
+  })
+
+  it("returns non-URL input unchanged", () => {
+    expect(sanitiseUrl("not a url")).toBe("not a url")
+  })
+})
+
+describe("sanitiseArgs", () => {
+  it("redacts the value after --github-token", () => {
+    expect(sanitiseArgs(["--github-token", "ghp_XXXXXXXX", "--json"])).toEqual([
+      "--github-token",
+      "REDACTED",
+      "--json",
+    ])
+  })
+
+  it("redacts --flag=value form", () => {
+    expect(sanitiseArgs(["--github-token=ghp_abc", "--json"])).toEqual(["--github-token=REDACTED", "--json"])
+  })
+
+  it("leaves non-sensitive flags alone", () => {
+    expect(sanitiseArgs(["--budget", "2000", "--quality"])).toEqual(["--budget", "2000", "--quality"])
+  })
+
+  it("does not redact language (not a secret, and needed to replay calls)", () => {
+    expect(sanitiseArgs(["-l", "fr", "--quality"])).toEqual(["-l", "fr", "--quality"])
+    expect(sanitiseArgs(["--language", "de"])).toEqual(["--language", "de"])
+  })
+})
+
+describe("history store", () => {
+  let dir: string
+  let originalHome: string | undefined
+  let originalXdg: string | undefined
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rdrr-hist-"))
+    originalHome = process.env["HOME"]
+    originalXdg = process.env["XDG_STATE_HOME"]
+    process.env["XDG_STATE_HOME"] = dir
+  })
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome
+    if (originalXdg !== undefined) process.env["XDG_STATE_HOME"] = originalXdg
+    else delete process.env["XDG_STATE_HOME"]
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it("writes and reads back entries", () => {
+    recordHistory({
+      ts: "2026-04-18T00:00:00Z",
+      url: "https://a/",
+      title: "A",
+      tokens: 10,
+      durationMs: 12,
+      args: [],
+    })
+    recordHistory({
+      ts: "2026-04-18T00:01:00Z",
+      url: "https://b/",
+      title: "B",
+      tokens: 20,
+      durationMs: 22,
+      args: [],
+    })
+
+    const entries = readHistory()
+    expect(entries).toHaveLength(2)
+    expect(entries[1]!.url).toBe("https://b/")
+
+    const raw = readFileSync(historyPath(), "utf-8")
+    expect(raw.split("\n").filter(Boolean)).toHaveLength(2)
+  })
+
+  it("rotates the log when it exceeds the 1000-entry cap", () => {
+    for (let i = 0; i < 1005; i++) {
+      recordHistory({
+        ts: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+        url: `https://example.com/${i}`,
+        title: `Entry ${i}`,
+        tokens: 1,
+        durationMs: 1,
+        args: [],
+      })
+    }
+    const entries = readHistory()
+    // The cap is 1000; once we cross it the oldest entries are dropped.
+    expect(entries.length).toBeLessThanOrEqual(1000)
+    expect(entries[entries.length - 1]!.url).toBe("https://example.com/1004")
+    expect(entries[0]!.url).not.toBe("https://example.com/0")
+  })
+
+  it("filters by search/since and applies limit", () => {
+    const now = Date.now()
+    const entries = [
+      { ts: new Date(now - 60_000).toISOString(), url: "https://react.dev", title: "React", tokens: 1, durationMs: 1, args: [] },
+      { ts: new Date(now - 30_000).toISOString(), url: "https://vue.dev", title: "Vue", tokens: 1, durationMs: 1, args: [] },
+      { ts: new Date(now).toISOString(), url: "https://react.dev/learn", title: "React Learn", tokens: 1, durationMs: 1, args: [] },
+    ]
+    const filtered = filterHistory(entries, { search: "react", limit: 1 })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]!.url).toBe("https://react.dev/learn")
+    const since = filterHistory(entries, { since: new Date(now - 45_000) })
+    expect(since).toHaveLength(2)
+  })
+})

--- a/src/cli/__tests__/quality.test.ts
+++ b/src/cli/__tests__/quality.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import type { ParseResult } from "../../types"
+import { computeQuality } from "../quality"
+
+const base = (overrides: Partial<ParseResult>): ParseResult => ({
+  type: "webpage",
+  title: "Example",
+  author: "",
+  content: "",
+  description: "",
+  domain: "example.com",
+  siteName: "",
+  published: null,
+  wordCount: 0,
+  readTime: "1 min",
+  ...overrides,
+})
+
+describe("computeQuality", () => {
+  it("scores long, well-structured articles as good", () => {
+    const content = Array.from({ length: 10 }, (_, i) => `Paragraph ${i}. ${"text ".repeat(30)}`).join("\n\n")
+    const report = computeQuality(base({ content, author: "Alice" }))
+    expect(report.verdict).toBe("good")
+    expect(report.score).toBeGreaterThanOrEqual(70)
+    expect(report.signals.hasByline).toBe(true)
+  })
+
+  it("scores link-heavy navigation-like content as partial or poor", () => {
+    const content = Array.from({ length: 5 }, (_, i) => `[link ${i}](https://x/${i})`).join(" ")
+    const report = computeQuality(base({ content }))
+    expect(report.signals.linkRatio).toBeGreaterThan(0.5)
+    expect(report.score).toBeLessThan(70)
+  })
+
+  it("caps the score at 30 when a paywall marker is present", () => {
+    const content = `${"legitimate prose ".repeat(200)}\n\nSubscribe to read the full article`
+    const report = computeQuality(base({ content, author: "Alice" }))
+    expect(report.score).toBeLessThanOrEqual(30)
+    expect(report.verdict).toBe("poor")
+  })
+
+  it("counts boilerplate phrases against the score", () => {
+    const content = `Accept all cookies\n\nManage preferences\n\nSign in\n\nSubscribe now\n\nPrivacy policy`
+    const report = computeQuality(base({ content }))
+    // Five hits saturates the boilerplate signal, which caps at 4.
+    expect(report.signals.boilerplateRatio).toBe(1)
+    expect(report.score).toBeLessThan(50)
+  })
+
+  it("flags non-English boilerplate (Russian, German, French, Spanish)", () => {
+    const content = [
+      "Принять все cookie",
+      "Политика конфиденциальности",
+      "Alle Cookies akzeptieren",
+      "Politique de confidentialité",
+      "Aceptar todas las cookies",
+    ].join("\n\n")
+    const report = computeQuality(base({ content }))
+    expect(report.signals.boilerplateRatio).toBeGreaterThan(0)
+  })
+
+  it("caps the score when a Russian paywall marker appears", () => {
+    const content = `${"осмысленный текст ".repeat(200)}\n\nТолько для подписчиков`
+    const report = computeQuality(base({ content, author: "Автор" }))
+    expect(report.score).toBeLessThanOrEqual(30)
+  })
+
+  it("treats essentially-empty content as poor regardless of metadata", () => {
+    // Bug: link-ratio bonus was firing on empty content, giving it 60/partial
+    // even when there was nothing to extract. Empty means poor, full stop.
+    expect(computeQuality(base({ content: "" })).verdict).toBe("poor")
+    expect(computeQuality(base({ content: "tiny", title: "Nice Title", author: "Someone" })).verdict).toBe("poor")
+  })
+})

--- a/src/cli/budget.ts
+++ b/src/cli/budget.ts
@@ -1,0 +1,92 @@
+/**
+ * Approximate token count using a fixed char-per-token ratio.
+ *
+ * Real tokenizers (cl100k_base, o200k_base) live in tiktoken/gpt-tokenizer
+ * and weigh >1 MB. For an LLM context-budget guardrail we don't need exactness
+ * — a slightly conservative estimate that never *overshoots* real token counts
+ * is the win. Empirically 4 chars/token matches BPE tokenizers within ~10% on
+ * English prose and undercounts on Cyrillic/CJK (which is safe for budgeting).
+ */
+const CHARS_PER_TOKEN = 4
+
+export const estimateTokens = (text: string): number => Math.ceil(text.length / CHARS_PER_TOKEN)
+
+interface TruncationInfo {
+  kept: number
+  total: number
+  omittedTokens: number
+  totalTokens: number
+}
+
+interface TruncateResult {
+  content: string
+  info: TruncationInfo | null
+}
+
+/**
+ * Truncate `content` so the rendered output stays at or below `budget` tokens.
+ *
+ * Chooses paragraph boundaries (double-newline) so we never end a cut inside a
+ * sentence. Tracks fenced-code-block state so a multi-paragraph code block is
+ * never split down the middle — leaving an unclosed ``` in the output. The
+ * first paragraph (usually the title/lede) is always kept even if it alone
+ * exceeds the budget, so the caller retains document head for context.
+ *
+ * Returns `info: null` when nothing had to be dropped — the caller should then
+ * decide whether to add any JSON field.
+ *
+ * The budget covers the content body only; frontmatter added by the CLI around
+ * this string is not tracked here. For agent workflows that's the right level —
+ * agents care about the text they'll actually reason over.
+ */
+export const truncateToBudget = (content: string, budget: number): TruncateResult => {
+  const totalTokens = estimateTokens(content)
+  if (totalTokens <= budget) return { content, info: null }
+
+  const paragraphs = splitParagraphs(content)
+  const kept: string[] = []
+  let keptTokens = 0
+  let fenceOpen = false
+
+  for (const [index, para] of paragraphs.entries()) {
+    const paraTokens = estimateTokens(para) + 1 // account for paragraph separator
+    const fits = keptTokens + paraTokens <= budget
+    // Always keep the first paragraph so the reader has the document head even
+    // when the budget is too small for anything else — otherwise the output is
+    // just a truncation marker with no context.
+    const forceKeep = index === 0
+    // If we're in the middle of a fenced code block, keep paragraphs until the
+    // fence closes so we never emit markdown with a dangling ```.
+    if (!fits && !forceKeep && !fenceOpen) break
+
+    kept.push(para)
+    keptTokens += paraTokens
+    if (countFenceToggles(para) % 2 === 1) fenceOpen = !fenceOpen
+  }
+
+  // If head-preservation ended up keeping everything the caller had, the
+  // "truncated" framing would be misleading: the output is actually complete.
+  // Report it the same way an under-budget input does.
+  if (kept.length === paragraphs.length) return { content, info: null }
+
+  // If we exited while a fence was still open, synthesise a closing fence so
+  // downstream parsers don't trip on a half-open block.
+  const closingFence = fenceOpen ? "\n```" : ""
+  const safeBody = kept.join("\n\n") + closingFence
+  const omittedTokens = Math.max(0, totalTokens - keptTokens)
+  const marker = `\n\n[truncated ${omittedTokens} tokens, ${totalTokens} total]`
+
+  return {
+    content: safeBody + marker,
+    info: { kept: kept.length, total: paragraphs.length, omittedTokens, totalTokens },
+  }
+}
+
+const splitParagraphs = (content: string): string[] => content.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean)
+
+const countFenceToggles = (para: string): number => {
+  // Count only fence markers that sit at the start of a line; inline triple
+  // backticks inside prose don't open a real code block.
+  const matches = para.match(/^```/gm)
+  return matches ? matches.length : 0
+}

--- a/src/cli/clipboard.ts
+++ b/src/cli/clipboard.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process"
+
+interface ClipboardBackend {
+  command: string
+  args: string[]
+}
+
+const PLATFORM_BACKENDS: Record<string, ClipboardBackend[]> = {
+  darwin: [{ command: "pbcopy", args: [] }],
+  linux: [
+    { command: "wl-copy", args: [] },
+    { command: "xclip", args: ["-selection", "clipboard"] },
+    { command: "xsel", args: ["--clipboard", "--input"] },
+  ],
+  win32: [{ command: "clip.exe", args: [] }],
+}
+
+/**
+ * Write `text` to the system clipboard using whichever backend the platform
+ * provides. Rejects with a descriptive error when nothing is installed so the
+ * CLI can print a user-facing diagnostic rather than crashing with ENOENT.
+ */
+export const copyToClipboard = async (text: string): Promise<string> => {
+  const backends = PLATFORM_BACKENDS[process.platform] ?? []
+  if (backends.length === 0) throw new Error(`No clipboard backend for platform "${process.platform}"`)
+
+  const failures: string[] = []
+  for (const { command, args } of backends) {
+    try {
+      await runBackend(command, args, text)
+      return command
+    } catch (err) {
+      failures.push(`${command}: ${(err as Error).message}`)
+    }
+  }
+  throw new Error(`No clipboard backend found. Tried: ${failures.join(", ")}`)
+}
+
+const runBackend = (command: string, args: string[], text: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["pipe", "ignore", "pipe"] })
+    let stderr = ""
+    let settled = false
+    const done = (err?: Error): void => {
+      if (settled) return
+      settled = true
+      if (err) reject(err)
+      else resolve()
+    }
+
+    child.on("error", (err) => done(err))
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+    child.on("close", (code) => {
+      if (code === 0) done()
+      else done(new Error(stderr.trim() || `exited with code ${code}`))
+    })
+
+    // Writable.end handles internal buffering, but an early EPIPE (e.g. the
+    // backend died before we finished writing) would otherwise bubble as an
+    // uncaught stream error. Forward it into the promise so the caller sees a
+    // clean rejection.
+    child.stdin.on("error", (err) => done(err))
+    child.stdin.end(text, "utf-8")
+  })

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,0 +1,80 @@
+import type { ParseResult } from "../types"
+
+export type OutputFormat = "md" | "json" | "jsonl" | "xml"
+
+/**
+ * CLI-level augmentation of a `ParseResult` with optional reports attached
+ * downstream (`--quality`, `--budget`). Keeping a single shape avoids ad-hoc
+ * casts at every render site and gives consumers typed access.
+ */
+export interface EnrichedResult extends ParseResult {
+  quality?: { score: number; verdict: "good" | "partial" | "poor" }
+  truncated?: { omittedTokens: number; totalTokens: number; kept: number; total: number }
+}
+
+export const parseFormat = (value: string): OutputFormat => {
+  if (value === "md" || value === "json" || value === "jsonl" || value === "xml") return value
+  throw new Error(`Unsupported format: ${value}`)
+}
+
+/**
+ * Render a result as JSONL — one JSON object per line. For a single URL this is
+ * a single line; aggregate callers stream multiple lines by concatenating calls.
+ */
+export const renderJsonl = (result: EnrichedResult | Array<EnrichedResult>): string => {
+  const items = Array.isArray(result) ? result : [result]
+  return items.map((r) => JSON.stringify(r)).join("\n") + (items.length > 0 ? "\n" : "")
+}
+
+interface XmlOptions {
+  source: string
+  fetchedAt: string
+}
+
+/**
+ * Render as LLM-friendly XML: metadata as attributes/elements, body as CDATA
+ * so markdown special chars and <...>-like fragments inside the article text
+ * don't need escaping or produce malformed XML. Emits an XML declaration so
+ * strict parsers accept the output as a standalone document, not a fragment.
+ */
+export const renderXml = (result: EnrichedResult, { source, fetchedAt }: XmlOptions): string => {
+  const type = escapeAttr(result.type)
+  const url = escapeAttr(source)
+  const lines: string[] = []
+  lines.push(`<?xml version="1.0" encoding="UTF-8"?>`)
+  lines.push(`<article type="${type}" url="${url}" fetchedAt="${escapeAttr(fetchedAt)}">`)
+  lines.push("  <meta>")
+  lines.push(`    <title>${escapeXml(result.title)}</title>`)
+  if (result.author) lines.push(`    <author>${escapeXml(result.author)}</author>`)
+  if (result.siteName) lines.push(`    <site>${escapeXml(result.siteName)}</site>`)
+  if (result.language) lines.push(`    <lang>${escapeXml(result.language)}</lang>`)
+  if (result.published) lines.push(`    <publishedAt>${escapeXml(result.published)}</publishedAt>`)
+  if (result.description) lines.push(`    <description>${escapeXml(result.description)}</description>`)
+  if (result.readTime) lines.push(`    <readTime>${escapeXml(result.readTime)}</readTime>`)
+  lines.push(`    <wordCount>${result.wordCount}</wordCount>`)
+  lines.push("  </meta>")
+
+  if (result.quality) {
+    lines.push(`  <quality score="${result.quality.score}" verdict="${escapeAttr(result.quality.verdict)}"/>`)
+  }
+
+  if (result.truncated) {
+    lines.push(
+      `  <truncated omittedTokens="${result.truncated.omittedTokens}" totalTokens="${result.truncated.totalTokens}"/>`,
+    )
+  }
+
+  lines.push(`  <content><![CDATA[${escapeCdata(result.content)}]]></content>`)
+  lines.push("</article>")
+  return lines.join("\n") + "\n"
+}
+
+const escapeXml = (s: string): string =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+
+const escapeAttr = (s: string): string =>
+  escapeXml(s).replace(/"/g, "&quot;").replace(/\n/g, " ")
+
+// `]]>` would prematurely close the CDATA section; split it so the sequence
+// never appears literally inside the wrapper.
+const escapeCdata = (s: string): string => s.split("]]>").join("]]]]><![CDATA[>")

--- a/src/cli/history.ts
+++ b/src/cli/history.ts
@@ -1,0 +1,162 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+
+interface HistoryEntry {
+  ts: string
+  url: string
+  title: string
+  tokens: number
+  quality?: number
+  durationMs: number
+  args: string[]
+}
+
+const MAX_ENTRIES = 1000
+
+/**
+ * XDG-style path that also works on macOS. macOS has no canonical XDG dir, so
+ * the issue asks us to reuse `~/.local/state/rdrr/history.jsonl`. Windows reads
+ * $LOCALAPPDATA when XDG_STATE_HOME is unset, so that path can be set by the
+ * user if needed; otherwise we fall back to the same dotpath.
+ */
+export const historyPath = (): string => {
+  const base = process.env["XDG_STATE_HOME"] ?? join(homedir(), ".local", "state")
+  return resolve(base, "rdrr", "history.jsonl")
+}
+
+const isHistoryDisabled = (): boolean => process.env["RDRR_NO_HISTORY"] === "1"
+
+export const recordHistory = (entry: HistoryEntry): void => {
+  if (isHistoryDisabled()) return
+  const path = historyPath()
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    appendFileSync(path, JSON.stringify(entry) + "\n", "utf-8")
+    rotate(path)
+  } catch (err) {
+    // History is best-effort: logging must never break the primary request.
+    // Surface the reason when the user opts in via RDRR_DEBUG so silent
+    // failures (permissions, full disk) are still diagnosable.
+    if (process.env["RDRR_DEBUG"] === "1") {
+      const msg = err instanceof Error ? err.message : String(err)
+      process.stderr.write(`[rdrr:history] ${msg}\n`)
+    }
+  }
+}
+
+export const readHistory = (): HistoryEntry[] => {
+  const path = historyPath()
+  if (!existsSync(path)) return []
+  const raw = readFileSync(path, "utf-8")
+  const entries: HistoryEntry[] = []
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      entries.push(JSON.parse(trimmed) as HistoryEntry)
+    } catch {
+      // Skip malformed lines rather than aborting the whole read; a single bad
+      // write shouldn't make `rdrr history` stop working for the user.
+    }
+  }
+  return entries
+}
+
+/**
+ * Query params whose values are dropped when writing to history. Keeps the
+ * parameter *name* so the URL still round-trips to something recognisable,
+ * while keeping tokens out of the log.
+ */
+const SENSITIVE_QUERY_KEYS = new Set([
+  "api_key",
+  "apikey",
+  "access_token",
+  "auth",
+  "authorization",
+  "key",
+  "password",
+  "secret",
+  "token",
+])
+
+/**
+ * Strip basic-auth credentials and redact values of common secret-bearing
+ * query parameters before logging so history files can't leak tokens that
+ * happened to be in the URL the user typed.
+ */
+export const sanitiseUrl = (url: string): string => {
+  try {
+    const u = new URL(url)
+    u.username = ""
+    u.password = ""
+    // Snapshot keys before mutating — `set` while iterating `keys()` is
+    // implementation-defined on URLSearchParams.
+    const keys: string[] = []
+    for (const key of u.searchParams.keys()) keys.push(key)
+    for (const key of keys) {
+      if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) u.searchParams.set(key, "REDACTED")
+    }
+    return u.toString()
+  } catch {
+    return url
+  }
+}
+
+/**
+ * CLI flags that take a secret/identifying value. When recording history we
+ * keep the flag name (so the shape of the call is visible) but drop its value.
+ *
+ * `-l`/`--language` is *not* in this list — a language code is a user setting,
+ * not a secret, and redacting it would make `--args` unreproducible for
+ * `rdrr last --fetch`-style workflows.
+ */
+const SENSITIVE_FLAGS = new Set(["--github-token", "--user-agent"])
+
+/**
+ * Redact values of sensitive flags in a raw argv slice. Assumes the input is
+ * the argv that was actually passed to `rdrr` (positional URL already stripped
+ * by the caller).
+ */
+export const sanitiseArgs = (args: string[]): string[] => {
+  const out: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!
+    out.push(a)
+    if (SENSITIVE_FLAGS.has(a) && i + 1 < args.length) {
+      out.push("REDACTED")
+      i++
+    } else if (a.includes("=")) {
+      const eq = a.indexOf("=")
+      const flag = a.slice(0, eq)
+      if (SENSITIVE_FLAGS.has(flag)) out[out.length - 1] = `${flag}=REDACTED`
+    }
+  }
+  return out
+}
+
+interface HistoryFilter {
+  limit?: number
+  search?: string
+  since?: Date
+}
+
+export const filterHistory = (entries: HistoryEntry[], filter: HistoryFilter = {}): HistoryEntry[] => {
+  let out = entries
+  if (filter.since) out = out.filter((e) => new Date(e.ts) >= filter.since!)
+  if (filter.search) {
+    const q = filter.search.toLowerCase()
+    out = out.filter((e) => e.url.toLowerCase().includes(q) || e.title.toLowerCase().includes(q))
+  }
+  out = [...out].reverse()
+  if (filter.limit !== undefined) out = out.slice(0, filter.limit)
+  return out
+}
+
+const rotate = (path: string): void => {
+  const raw = readFileSync(path, "utf-8")
+  const lines = raw.split(/\r?\n/).filter(Boolean)
+  if (lines.length <= MAX_ENTRIES) return
+  const trimmed = lines.slice(-MAX_ENTRIES).join("\n") + "\n"
+  writeFileSync(path, trimmed, "utf-8")
+}

--- a/src/cli/quality.ts
+++ b/src/cli/quality.ts
@@ -1,0 +1,169 @@
+import type { ParseResult } from "../types"
+
+interface QualitySignals {
+  textDensity: number
+  linkRatio: number
+  paragraphCount: number
+  hasTitle: boolean
+  hasByline: boolean
+  contentLength: number
+  boilerplateRatio: number
+}
+
+interface QualityReport {
+  score: number
+  signals: QualitySignals
+  verdict: "good" | "partial" | "poor"
+}
+
+/**
+ * Boilerplate phrases that signal navigation chrome, consent walls, or marketing
+ * ribbons rather than the article the caller asked for. A high concentration of
+ * these in extracted "content" tells the caller the extractor probably missed
+ * the real article body. Covers the biggest consent-banner / paywall surfaces
+ * in English, Russian, German, French, Spanish — the same copy tends to repeat
+ * across CMS themes, so exact matches catch most cases without heuristics.
+ */
+const BOILERPLATE_PHRASES = [
+  // English
+  /\baccept (all )?cookies\b/i,
+  /\bmanage preferences\b/i,
+  /\bsign in\b/i,
+  /\bsubscribe (now|to continue|for (full|unlimited))\b/i,
+  /\bcreate (an )?account\b/i,
+  /\bby continuing to use\b/i,
+  /\bprivacy policy\b/i,
+  /\bterms of service\b/i,
+  // Russian
+  /принять (все )?(cookie|куки)/i,
+  /политика конфиденциальности/i,
+  /условия использования/i,
+  /подписаться/i,
+  /войти в аккаунт/i,
+  // German
+  /alle cookies akzeptieren/i,
+  /datenschutz(erkl[aä]rung| policy)/i,
+  /nutzungsbedingungen/i,
+  // French
+  /accepter (tous les )?cookies/i,
+  /politique de confidentialit[eé]/i,
+  /conditions d[’']utilisation/i,
+  // Spanish
+  /aceptar (todas las )?cookies/i,
+  /pol[ií]tica de privacidad/i,
+  /t[eé]rminos (del servicio|de uso)/i,
+]
+
+const PAYWALL_MARKERS = [
+  /\bpaywall\b/i,
+  /subscribe to (read|continue|unlock)/i,
+  /unlock (the )?full article/i,
+  /только для подписчиков/i, // RU
+  /nur für abonnenten/i, // DE
+  /r[eé]serv[eé] aux abonn[eé]s/i, // FR
+  /solo para suscriptores/i, // ES
+]
+const CAPTCHA_MARKERS = [/please verify you are human/i, /cloudflare.*checking your browser/i]
+
+// Scoring thresholds. Tuned empirically against a spread of article pages;
+// adjust in one place rather than threading literals through the scoring body.
+const BASE_SCORE = 50
+const LONG_ARTICLE_CHARS = 2000
+const MEDIUM_ARTICLE_CHARS = 500
+const LONG_ARTICLE_BONUS = 20
+const MEDIUM_ARTICLE_BONUS = 10
+const DENSE_PARAGRAPHS = 6
+const SPARSE_PARAGRAPHS = 2
+const DENSE_PARAGRAPH_BONUS = 10
+const SPARSE_PARAGRAPH_BONUS = 5
+const METADATA_BONUS = 5
+const LOW_LINK_RATIO = 0.25
+const HIGH_LINK_RATIO = 0.5
+const LINK_BONUS = 10
+const LINK_PENALTY = 10
+const BOILERPLATE_WEIGHT = 40
+const PAYWALL_SCORE_CAP = 30
+const GOOD_VERDICT_THRESHOLD = 70
+const PARTIAL_VERDICT_THRESHOLD = 40
+
+// Content shorter than this is treated as "essentially empty": the page either
+// failed to extract, was a thin stub, or was redirected away. We skip the
+// positive bonuses (title/byline/links) so the score reflects the truth
+// instead of being propped up by metadata we shouldn't trust.
+const EMPTY_CONTENT_CHARS = 20
+
+export const computeQuality = (result: ParseResult): QualityReport => {
+  const content = result.content
+  const signals = computeSignals(result, content)
+
+  // Essentially-empty content is "poor" outright — no amount of metadata or
+  // link-ratio gaming rescues a page with no body.
+  if (signals.contentLength < EMPTY_CONTENT_CHARS) {
+    return { score: 0, signals, verdict: "poor" }
+  }
+
+  let score = BASE_SCORE
+  if (signals.contentLength > LONG_ARTICLE_CHARS) score += LONG_ARTICLE_BONUS
+  else if (signals.contentLength > MEDIUM_ARTICLE_CHARS) score += MEDIUM_ARTICLE_BONUS
+  if (signals.paragraphCount > DENSE_PARAGRAPHS) score += DENSE_PARAGRAPH_BONUS
+  else if (signals.paragraphCount > SPARSE_PARAGRAPHS) score += SPARSE_PARAGRAPH_BONUS
+  if (signals.hasTitle) score += METADATA_BONUS
+  if (signals.hasByline) score += METADATA_BONUS
+  if (signals.linkRatio < LOW_LINK_RATIO) score += LINK_BONUS
+  else if (signals.linkRatio > HIGH_LINK_RATIO) score -= LINK_PENALTY
+  score -= Math.round(signals.boilerplateRatio * BOILERPLATE_WEIGHT)
+  if (hasMatch(content, PAYWALL_MARKERS) || hasMatch(content, CAPTCHA_MARKERS)) {
+    score = Math.min(score, PAYWALL_SCORE_CAP)
+  }
+
+  score = Math.max(0, Math.min(100, score))
+  const verdict: QualityReport["verdict"] =
+    score >= GOOD_VERDICT_THRESHOLD ? "good" : score >= PARTIAL_VERDICT_THRESHOLD ? "partial" : "poor"
+  return { score, signals, verdict }
+}
+
+const computeSignals = (result: ParseResult, content: string): QualitySignals => {
+  const plainText = stripMarkdown(content)
+  const linkTextLength = countLinkTextLength(content)
+  const contentLength = plainText.length
+  const boilerplateRatio = computeBoilerplateRatio(content)
+  return {
+    textDensity: content.length > 0 ? plainText.length / content.length : 0,
+    linkRatio: plainText.length > 0 ? Math.min(1, linkTextLength / plainText.length) : 0,
+    paragraphCount: content.split(/\n{2,}/).filter((p) => p.trim().length > 0).length,
+    hasTitle: Boolean(result.title?.trim()),
+    hasByline: Boolean(result.author?.trim()),
+    contentLength,
+    boilerplateRatio,
+  }
+}
+
+const stripMarkdown = (md: string): string =>
+  md
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`]*`/g, "")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[#>*_~-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+
+const countLinkTextLength = (md: string): number => {
+  let total = 0
+  for (const m of md.matchAll(/\[([^\]]+)\]\([^)]*\)/g)) total += m[1]!.length
+  return total
+}
+
+// Boilerplate signal caps at `SATURATION_HITS` matches — beyond that the
+// density is already high enough to flag the page and we don't want the
+// ratio to dilute when more language-specific phrases are added to the list.
+const BOILERPLATE_SATURATION_HITS = 4
+
+const computeBoilerplateRatio = (content: string): number => {
+  if (!content.trim()) return 0
+  let hits = 0
+  for (const pattern of BOILERPLATE_PHRASES) if (pattern.test(content)) hits++
+  return Math.min(hits, BOILERPLATE_SATURATION_HITS) / BOILERPLATE_SATURATION_HITS
+}
+
+const hasMatch = (content: string, patterns: RegExp[]): boolean => patterns.some((p) => p.test(content))

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -25,19 +25,47 @@ const X_RESERVED_HANDLES = new Set([
 ])
 
 const X_PROFILE_HANDLE = /^\/([A-Za-z0-9_]{1,15})\/?$/
+const X_STATUS_BY_HANDLE = /^\/([A-Za-z0-9_]{1,15})\/status\/(\d+)\/?$/
+const X_STATUS_BY_ID = /^\/i\/status\/(\d+)\/?$/
 
 const GITHUB_ISSUE_PR = /github\.com\/[^/]+\/[^/]+\/(issues|pull)\/\d+/
 const GITHUB_FILE = /github\.com\/[^/]+\/[^/]+\/blob\/.+/
-export type UrlType = "youtube" | "github-issue" | "github-file" | "pdf" | "x-profile" | "webpage"
+export type UrlType = "youtube" | "github-issue" | "github-file" | "pdf" | "x-profile" | "x-status" | "webpage"
 
 export const detectUrlType = (url: string): UrlType => {
   if (isYouTube(url)) return "youtube"
   if (GITHUB_ISSUE_PR.test(url)) return "github-issue"
   if (GITHUB_FILE.test(url)) return "github-file"
   if (isPdf(url)) return "pdf"
+  if (isXStatus(url)) return "x-status"
   if (isXProfile(url)) return "x-profile"
   return "webpage"
 }
+
+interface XStatusRef {
+  handle: string | null
+  id: string
+}
+
+export const extractXStatus = (url: string): XStatusRef | null => {
+  try {
+    const u = new URL(url)
+    if (!X_HOSTS.has(u.hostname)) return null
+
+    const byId = u.pathname.match(X_STATUS_BY_ID)
+    if (byId?.[1]) return { handle: null, id: byId[1] }
+
+    const byHandle = u.pathname.match(X_STATUS_BY_HANDLE)
+    if (!byHandle?.[2]) return null
+    const handle = byHandle[1] ?? ""
+    if (X_RESERVED_HANDLES.has(handle.toLowerCase())) return null
+    return { handle, id: byHandle[2] }
+  } catch {
+    return null
+  }
+}
+
+const isXStatus = (url: string): boolean => extractXStatus(url) !== null
 
 export const extractXHandle = (url: string): string | null => {
   try {

--- a/src/extract/__tests__/engine-markdown.test.ts
+++ b/src/extract/__tests__/engine-markdown.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { extract, extractAsync, parseLinkedomHTML } from ".."
+
+describe("parseLinkedomHTML edge cases", () => {
+  it("does not crash on empty input", () => {
+    // Regression: linkedom threw from deep inside its internals on empty
+    // input, surfacing as "Cannot destructure property 'firstElementChild' of
+    // 'e' as it is null" in the CLI.
+    const doc = parseLinkedomHTML("")
+    expect(doc.documentElement).toBeDefined()
+    expect(doc.body).toBeDefined()
+  })
+
+  it("does not crash on whitespace-only input", () => {
+    const doc = parseLinkedomHTML("   \n\t  ")
+    expect(doc.documentElement).toBeDefined()
+  })
+})
+
+const HTML = `<!doctype html><html><head><title>Doc</title></head><body>
+  <main><h1>Heading</h1><p>Paragraph with <strong>bold</strong> text.</p></main>
+</body></html>`
+
+describe("extract/extractAsync honour options.markdown", () => {
+  it("returns raw HTML by default", () => {
+    const doc = parseLinkedomHTML(HTML)
+    const result = extract(doc, { url: "https://example.com/doc" })
+    expect(/<\w+[^>]*>/.test(result.content)).toBe(true)
+  })
+
+  it("converts to markdown when markdown:true is passed", () => {
+    const doc = parseLinkedomHTML(HTML)
+    const result = extract(doc, { url: "https://example.com/doc", markdown: true })
+    // Markdown output should no longer contain HTML tags and should use ** for bold.
+    expect(/<[^>]+>/.test(result.content)).toBe(false)
+    expect(result.content).toMatch(/\*\*bold\*\*/)
+  })
+
+  it("extractAsync also converts when markdown:true is passed", async () => {
+    const doc = parseLinkedomHTML(HTML)
+    const result = await extractAsync(doc, { url: "https://example.com/doc", markdown: true })
+    expect(/<[^>]+>/.test(result.content)).toBe(false)
+    expect(result.content).toMatch(/\*\*bold\*\*/)
+  })
+})

--- a/src/extract/engine.ts
+++ b/src/extract/engine.ts
@@ -9,54 +9,87 @@ import { filterHiddenElements } from "./filters/hidden"
 import { filterBySelectors, filterContentPatterns } from "./filters/patterns"
 import { filterLowScoringBlocks } from "./filters/scoring"
 import { filterSmallImages } from "./filters/small-images"
-import { extractMetadata } from "./metadata"
+import { toMarkdown } from "./markdown"
+import { type Metadata, extractMetadata } from "./metadata"
 import { normaliseContent } from "./normalise"
 import { extractSchemaOrg, getSchemaText, findElementBySchemaText, collectMetaTags } from "./schema"
 import { findMainContent } from "./select"
 import { findSiteExtractor, findAsyncSiteExtractor } from "./sites/registry"
+import type { SiteExtractorResult } from "./sites/types"
 import { serializeHTML } from "./utils/dom"
+
+/**
+ * Minimum word count a pass must hit before we accept it. Below this the
+ * pipeline will retry with progressively looser filters and, as a last resort,
+ * take the longest attempt it made.
+ */
+const MIN_ACCEPTABLE_WORDS = 50
 
 export const extract = (doc: Document, options: ExtractOptions = {}): ExtractResult => {
   const url = options.url ?? ""
+  const viaSite = runSyncSiteExtractor(doc, url, options)
+  const raw = viaSite ?? runPipeline(doc, url, options)
+  return finaliseMarkdown(raw, options, url)
+}
 
-  // Try sync site extractors first
-  const siteExtractor = url ? findSiteExtractor(doc, url) : null
-  if (siteExtractor) {
-    const extracted = siteExtractor.extract()
-    if (extracted.contentSelector) {
-      // Extractor wants the engine to process a specific element
-      const pipelineResult = extractInternal(doc, url, {
-        ...options,
-        contentSelector: extracted.contentSelector,
-        removeLowScoring: false,
-        removeHiddenElements: false,
-      })
-      return mergeExtractorVariables(pipelineResult, extracted.variables)
-    }
-    if (extracted.contentHtml) {
-      const schemaOrg = extractSchemaOrg(doc)
-      const metaTags = collectMetaTags(doc)
-      const meta = extractMetadata(doc, schemaOrg, metaTags)
-      return {
-        title: extracted.variables?.title ?? meta.title,
-        author: extracted.variables?.author ?? meta.author,
-        content: extracted.contentHtml,
-        description: extracted.variables?.description ?? meta.description,
-        domain: meta.domain || (url ? safeDomain(url) : ""),
-        siteName: extracted.variables?.site ?? meta.siteName,
-        language: extracted.variables?.language ?? meta.language,
-        dir: meta.dir,
-        published: extracted.variables?.published ?? meta.published ?? null,
-        wordCount: countHtmlWords(extracted.contentHtml),
-      }
-    }
+export const extractAsync = async (doc: Document, options: ExtractOptions = {}): Promise<ExtractResult> => {
+  const url = options.url ?? ""
+  // Async site extractor short-circuits everything — an async site knows how
+  // to talk to its own API and the sync pipeline has nothing to add.
+  const asyncExtractor = findAsyncSiteExtractor(doc, url)
+  if (asyncExtractor?.extractAsync) {
+    const extracted = await asyncExtractor.extractAsync()
+    return finaliseMarkdown(buildResultFromExtractor(extracted, collectMeta(doc), url), options, url)
   }
 
-  // Build cache once, reuse across all retries
-  const _cache = getOrCreateCache(doc)
-  const opts = { ...options, _cache }
+  // Otherwise run the sync engine, then patch in an async extractor's result
+  // only if sync gave up. We pass `markdown: false` so the async fallback below
+  // doesn't convert HTML that will be replaced wholesale.
+  let result = extract(doc, { ...options, markdown: false })
+  if (result.wordCount === 0 && asyncExtractor?.extractAsync) {
+    const extracted = await asyncExtractor.extractAsync()
+    result = mergeAsyncFallback(result, extracted)
+  }
+  return finaliseMarkdown(result, options, url)
+}
 
-  // Collect all attempts for final safety net fallback
+/**
+ * Try a sync site extractor (e.g. reddit, hackernews, github). Returns the
+ * built result if one matched, or `null` to hand control to the readability
+ * pipeline. Encapsulates both site-extractor modes (`contentSelector` asks
+ * the engine to process a specific DOM subtree; `contentHtml` hands us a
+ * pre-rendered body).
+ */
+const runSyncSiteExtractor = (doc: Document, url: string, options: ExtractOptions): ExtractResult | null => {
+  if (!url) return null
+  const siteExtractor = findSiteExtractor(doc, url)
+  if (!siteExtractor) return null
+  const extracted = siteExtractor.extract()
+
+  if (extracted.contentSelector) {
+    const pipelineResult = extractInternal(doc, url, {
+      ...options,
+      contentSelector: extracted.contentSelector,
+      removeLowScoring: false,
+      removeHiddenElements: false,
+    })
+    return mergeExtractorVariables(pipelineResult, extracted.variables)
+  }
+  if (extracted.contentHtml) {
+    return buildResultFromExtractor(extracted, collectMeta(doc), url)
+  }
+  return null
+}
+
+/**
+ * Full readability pipeline with up to three retries (progressive loosening of
+ * filters) plus a schema.org rescue pass. Only entered when no site extractor
+ * handled the page.
+ */
+const runPipeline = (doc: Document, url: string, options: ExtractOptions): ExtractResult => {
+  const cache = getOrCreateCache(doc)
+  const opts: InternalOptions = { ...options, _cache: cache }
+
   const attempts: ExtractResult[] = []
   const tryExtract = (retryOpts: InternalOptions): ExtractResult => {
     const r = extractInternal(doc, url, retryOpts)
@@ -65,108 +98,127 @@ export const extract = (doc: Document, options: ExtractOptions = {}): ExtractRes
   }
 
   let result = tryExtract(opts)
-
-  if (result.wordCount < 50) {
-    const retry = tryExtract({ ...opts, removeHiddenElements: false })
-    if (retry.wordCount > result.wordCount * 2) result = retry
-
-    // Try targeting the largest hidden subtree directly
-    const hiddenSelector = findLargestHiddenContentSelector(doc)
-    if (hiddenSelector) {
-      const hiddenRetry = tryExtract({
-        ...opts,
-        removeHiddenElements: false,
-        contentSelector: hiddenSelector,
-      })
-      if (
-        hiddenRetry.wordCount > result.wordCount ||
-        (hiddenRetry.wordCount > Math.max(20, result.wordCount * 0.7) &&
-          hiddenRetry.content.length < result.content.length)
-      ) {
-        result = hiddenRetry
-      }
-    }
-  }
-
-  if (result.wordCount < 50) {
-    const retry = tryExtract({
-      ...opts,
-      removeLowScoring: false,
-    })
-    if (retry.wordCount > result.wordCount) result = retry
-  }
-
-  // Safety net: if all retries still failed, fall back to the longest attempt.
-  // Only triggers when the current pipeline already gave up (wordCount < 50),
-  // so happy-path output is unaffected.
-  if (result.wordCount < 50 && attempts.length > 1) {
-    const best = attempts.reduce((a, b) => (b.wordCount > a.wordCount ? b : a))
-    if (best.wordCount > result.wordCount) result = best
-  }
+  if (result.wordCount < MIN_ACCEPTABLE_WORDS) result = retryWithHiddenIncluded(result, doc, opts, tryExtract)
+  if (result.wordCount < MIN_ACCEPTABLE_WORDS) result = retryWithLowScoringKept(result, opts, tryExtract)
+  if (result.wordCount < MIN_ACCEPTABLE_WORDS) result = bestOfAttempts(result, attempts)
 
   stripUnsafeElements(doc)
 
-  const schemaText = getSchemaText(_cache.schemaOrg)
-  if (schemaText && countWords(schemaText) > result.wordCount * 1.5) {
-    const bestMatch = doc.body ? findElementBySchemaText(doc.body, schemaText) : null
-    if (bestMatch) {
-      const selector = getSelector(bestMatch, doc)
-      result = extractInternal(doc, url, { ...opts, contentSelector: selector })
-    } else {
-      result.content = schemaText
-      result.wordCount = countWords(schemaText)
-    }
-  }
-
-  return result
+  return rescueFromSchemaOrg(result, doc, url, opts, cache.schemaOrg)
 }
 
-export const extractAsync = async (doc: Document, options: ExtractOptions = {}): Promise<ExtractResult> => {
-  const url = options.url ?? ""
+const retryWithHiddenIncluded = (
+  current: ExtractResult,
+  doc: Document,
+  opts: InternalOptions,
+  tryExtract: (o: InternalOptions) => ExtractResult,
+): ExtractResult => {
+  let result = current
+  const retry = tryExtract({ ...opts, removeHiddenElements: false })
+  if (retry.wordCount > result.wordCount * 2) result = retry
 
-  // Try async site extractors first (e.g. X.com via FxTwitter API)
-  const asyncExtractor = findAsyncSiteExtractor(doc, url)
-  if (asyncExtractor?.extractAsync) {
-    const extracted = await asyncExtractor.extractAsync()
-    const schemaOrg = extractSchemaOrg(doc)
-    const metaTags = collectMetaTags(doc)
-    const meta = extractMetadata(doc, schemaOrg, metaTags)
+  // Target the largest visually-hidden subtree directly — some SPAs stash the
+  // full article inside an aria-hidden wrapper while only a skeleton is visible.
+  const hiddenSelector = findLargestHiddenContentSelector(doc)
+  if (!hiddenSelector) return result
 
-    return {
-      title: extracted.variables?.title ?? meta.title,
-      author: extracted.variables?.author ?? meta.author,
-      content: extracted.contentHtml,
-      description: extracted.variables?.description ?? meta.description,
-      domain: meta.domain,
-      siteName: extracted.variables?.site ?? meta.siteName,
-      language: extracted.variables?.language ?? meta.language,
-      dir: meta.dir,
-      published: extracted.variables?.published ?? meta.published ?? null,
-      wordCount: countHtmlWords(extracted.contentHtml),
-    }
+  const hiddenRetry = tryExtract({ ...opts, removeHiddenElements: false, contentSelector: hiddenSelector })
+  const beatsByWords = hiddenRetry.wordCount > result.wordCount
+  const similarWordsButTighter =
+    hiddenRetry.wordCount > Math.max(20, result.wordCount * 0.7) && hiddenRetry.content.length < result.content.length
+  return beatsByWords || similarWordsButTighter ? hiddenRetry : result
+}
+
+const retryWithLowScoringKept = (
+  current: ExtractResult,
+  opts: InternalOptions,
+  tryExtract: (o: InternalOptions) => ExtractResult,
+): ExtractResult => {
+  const retry = tryExtract({ ...opts, removeLowScoring: false })
+  return retry.wordCount > current.wordCount ? retry : current
+}
+
+/**
+ * Safety net: when the pipeline has already given up, take the longest attempt
+ * it made. Only runs when `current.wordCount < MIN_ACCEPTABLE_WORDS`, so the
+ * happy path is untouched.
+ */
+const bestOfAttempts = (current: ExtractResult, attempts: ExtractResult[]): ExtractResult => {
+  if (attempts.length <= 1) return current
+  const best = attempts.reduce((a, b) => (b.wordCount > a.wordCount ? b : a))
+  return best.wordCount > current.wordCount ? best : current
+}
+
+/**
+ * If schema.org JSON-LD describes a substantially longer article body than the
+ * pipeline extracted, reach for that element instead. Keeps us honest on SSR
+ * sites where the rendered DOM hides most of the prose behind interactive widgets.
+ */
+const rescueFromSchemaOrg = (
+  current: ExtractResult,
+  doc: Document,
+  url: string,
+  opts: InternalOptions,
+  schemaOrg: unknown[],
+): ExtractResult => {
+  const schemaText = getSchemaText(schemaOrg)
+  if (!schemaText || countWords(schemaText) <= current.wordCount * 1.5) return current
+
+  const bestMatch = doc.body ? findElementBySchemaText(doc.body, schemaText) : null
+  if (bestMatch) {
+    const selector = getSelector(bestMatch, doc)
+    return extractInternal(doc, url, { ...opts, contentSelector: selector })
   }
+  return { ...current, content: schemaText, wordCount: countWords(schemaText) }
+}
 
-  // Fall back to sync extract
-  const result = extract(doc, options)
+/**
+ * Merge an async-extractor result onto a (near-empty) sync result. Preserves
+ * every field the async extractor left unset (e.g. `domain`, `language`) so
+ * callers still see the metadata the sync pipeline gathered.
+ */
+const mergeAsyncFallback = (syncResult: ExtractResult, extracted: SiteExtractorResult): ExtractResult => ({
+  ...syncResult,
+  title: extracted.variables?.title ?? syncResult.title,
+  author: extracted.variables?.author ?? syncResult.author,
+  content: extracted.contentHtml,
+  siteName: extracted.variables?.site ?? syncResult.siteName,
+  published: extracted.variables?.published ?? syncResult.published,
+  wordCount: countHtmlWords(extracted.contentHtml),
+})
 
-  // If sync produced very little content, try async extractors as fallback
-  if (result.wordCount === 0) {
-    const fallback = findAsyncSiteExtractor(doc, url)
-    if (fallback?.extractAsync) {
-      const extracted = await fallback.extractAsync()
-      return {
-        ...result,
-        title: extracted.variables?.title ?? result.title,
-        author: extracted.variables?.author ?? result.author,
-        content: extracted.contentHtml,
-        siteName: extracted.variables?.site ?? result.siteName,
-        published: extracted.variables?.published ?? result.published,
-        wordCount: countHtmlWords(extracted.contentHtml),
-      }
-    }
-  }
+/**
+ * Build a canonical `ExtractResult` out of a site-extractor payload and the
+ * document metadata. Identical shape between sync and async code paths.
+ */
+const buildResultFromExtractor = (extracted: SiteExtractorResult, meta: Metadata, url: string): ExtractResult => ({
+  title: extracted.variables?.title ?? meta.title,
+  author: extracted.variables?.author ?? meta.author,
+  content: extracted.contentHtml,
+  description: extracted.variables?.description ?? meta.description,
+  domain: meta.domain || (url ? safeDomain(url) : ""),
+  siteName: extracted.variables?.site ?? meta.siteName,
+  language: extracted.variables?.language ?? meta.language,
+  dir: meta.dir,
+  published: extracted.variables?.published ?? meta.published ?? null,
+  wordCount: countHtmlWords(extracted.contentHtml),
+})
 
-  return result
+const collectMeta = (doc: Document): Metadata => {
+  const schemaOrg = extractSchemaOrg(doc)
+  const metaTags = collectMetaTags(doc)
+  return extractMetadata(doc, schemaOrg, metaTags)
+}
+
+/**
+ * Convert `result.content` from HTML to markdown when the caller asked for it
+ * via `options.markdown === true`. Preserves word count (computed from text, not
+ * markup) and leaves HTML in place for every other caller so existing consumers
+ * that do their own conversion downstream (e.g. provider/web.ts) aren't affected.
+ */
+const finaliseMarkdown = (result: ExtractResult, options: ExtractOptions, url: string): ExtractResult => {
+  if (options.markdown !== true || !result.content) return result
+  return { ...result, content: toMarkdown(result.content, url) }
 }
 
 interface InternalOptions extends ExtractOptions {

--- a/src/extract/sites/x-oembed.ts
+++ b/src/extract/sites/x-oembed.ts
@@ -59,6 +59,10 @@ interface FxResponse {
   }
 }
 
+// Used by `parseHtml`/extension callers that already have the rendered DOM
+// and want a site-extractor pass; the CLI `parse` path routes X status URLs
+// straight to `provider/x-status` (fxtwitter primary, syndication fallback)
+// and skips this branch entirely.
 registerSite({
   patterns: ["x.com"],
   create: (_doc, url) =>

--- a/src/extract/utils/parse-html.ts
+++ b/src/extract/utils/parse-html.ts
@@ -16,7 +16,12 @@ const makeComputedStyleStub = (): () => Record<string, unknown> => () =>
   new Proxy({}, COMPUTED_STYLE_STUB) as Record<string, unknown>
 
 export const parseLinkedomHTML = (html: string, url?: string): Document => {
-  const { document } = parseHTML(html)
+  // linkedom throws from deep inside its internals on empty/whitespace-only
+  // input ("Cannot destructure property 'firstElementChild' of 'e' as it is
+  // null"). Substitute a minimal valid shell so downstream code handles it
+  // like any other content-less document instead of crashing.
+  const safe = html && html.trim() ? html : "<!doctype html><html><head></head><body></body></html>"
+  const { document } = parseHTML(safe)
   const doc = document as unknown as Record<string, unknown>
   if (!doc.styleSheets) doc.styleSheets = []
   if (doc.defaultView && !(doc.defaultView as Record<string, unknown>).getComputedStyle) {

--- a/src/provider/_twitter/normalize.ts
+++ b/src/provider/_twitter/normalize.ts
@@ -1,0 +1,69 @@
+import type { FxFacet, FxRawText, FxStatus, NormalizedFacet, NormalizedMedia, NormalizedQuote } from "./types"
+
+/**
+ * Slice rawText by display_text_range and re-index facets into the sliced space.
+ * Drops `media` facets (those are t.co placeholders Twitter puts in text).
+ *
+ * FxEmbed facet indices are UTF-16 code-units (matching JS String semantics),
+ * so plain String#slice is correct.
+ */
+export const applyDisplayRange = (rt: FxRawText): { text: string; facets: NormalizedFacet[] } => {
+  const fullText = rt.text
+  const [rangeStart, rangeEnd] = rt.display_text_range ?? [0, fullText.length]
+  const text = fullText.slice(rangeStart, rangeEnd)
+
+  const facets: NormalizedFacet[] = []
+  for (const facet of rt.facets ?? []) {
+    const normalized = normalizeFacet(facet, rangeStart, rangeEnd)
+    if (normalized) facets.push(normalized)
+  }
+  facets.sort((a, b) => a.start - b.start)
+  return { text, facets }
+}
+
+const normalizeFacet = (facet: FxFacet, rangeStart: number, rangeEnd: number): NormalizedFacet | null => {
+  const [fStart, fEnd] = facet.indices
+  if (fEnd <= rangeStart || fStart >= rangeEnd) return null
+  if (facet.type === "media") return null
+
+  const start = Math.max(0, fStart - rangeStart)
+  const end = Math.min(rangeEnd - rangeStart, fEnd - rangeStart)
+  if (end <= start) return null
+
+  if (facet.type === "mention") {
+    const handle = facet.original ?? facet.text
+    if (!handle) return null
+    return { type: "mention", start, end, handle }
+  }
+  if (facet.type === "url") {
+    // FxEmbed exposes `replacement` as the real destination and `display` as the label.
+    const href = facet.replacement ?? facet.original
+    const display = facet.display ?? href ?? ""
+    if (!href) return null
+    return { type: "url", start, end, href, display }
+  }
+  return null
+}
+
+export const extractMedia = (status: FxStatus): NormalizedMedia[] => {
+  const all = status.media?.all ?? []
+  const out: NormalizedMedia[] = []
+  const seen = new Set<string>()
+  for (const m of all) {
+    if (!m.url || seen.has(m.url)) continue
+    seen.add(m.url)
+    const type = m.type === "video" || m.type === "gif" || m.type === "photo" ? m.type : "photo"
+    out.push({ type, url: m.url })
+  }
+  return out
+}
+
+export const normalizeQuote = (quote: FxStatus): NormalizedQuote => {
+  const rt = quote.raw_text
+  const { text } = applyDisplayRange(rt ?? { text: quote.text })
+  return {
+    author: { handle: quote.author.screen_name, name: quote.author.name },
+    text,
+    permalink: quote.url,
+  }
+}

--- a/src/provider/_twitter/render-utils.ts
+++ b/src/provider/_twitter/render-utils.ts
@@ -1,0 +1,62 @@
+/**
+ * Small rendering helpers shared by every markdown renderer that formats
+ * fxtwitter data (x-profile timeline, x-status single post). Each used to be
+ * forked across the two renderers; keeping them here removes ~25 LOC of drift
+ * risk per provider and a tiny amount of bundle weight.
+ */
+
+/**
+ * Validate and sanitize a URL before interpolating it into a markdown link target.
+ *
+ * Returns `null` for any input that:
+ *   - isn't a syntactically valid absolute URL
+ *   - uses a protocol other than `http:` or `https:` (blocks `javascript:`, `data:`, etc.)
+ *
+ * Otherwise returns the URL with `)` and whitespace percent-encoded so the link
+ * cannot be terminated early and subsequent bytes cannot leak into the surrounding
+ * markdown. This is the single gate every URL from the upstream API must pass
+ * through before reaching the output.
+ */
+export const safeUrl = (raw: string): string | null => {
+  if (!raw) return null
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null
+  return parsed.toString().replace(/\)/g, "%29").replace(/\s/g, "%20")
+}
+
+/**
+ * Escape characters that would otherwise hijack Markdown rendering.
+ * Conservative: only the handful that can break out of a paragraph or a link
+ * construct.
+ */
+export const escapeMarkdown = (s: string): string => s.replace(/([\\`*_[\]])/g, "\\$1")
+
+/**
+ * Prepare a free-form string (e.g. display name) for use as inline text in a
+ * heading or other single-line position. Drops newlines and leading markdown
+ * block markers so an attacker-controlled value cannot open a new block or
+ * forge additional structure, then applies the standard inline escape.
+ */
+export const sanitizeInline = (s: string): string =>
+  escapeMarkdown(s.replace(/[\r\n]+/g, " ").replace(/^[\s#>*-]+/, "").trim())
+
+const pad = (n: number): string => n.toString().padStart(2, "0")
+
+/**
+ * Format a Date as `YYYY-MM-DD HH:MM UTC`. Kept in UTC deliberately — X shows
+ * local time, but render targets (terminal, clipboard, LLM input) have no
+ * client timezone, so a stable UTC string is the least-surprising choice.
+ */
+export const formatDate = (d: Date): string => {
+  const y = d.getUTCFullYear()
+  const mo = pad(d.getUTCMonth() + 1)
+  const da = pad(d.getUTCDate())
+  const h = pad(d.getUTCHours())
+  const mi = pad(d.getUTCMinutes())
+  return `${y}-${mo}-${da} ${h}:${mi} UTC`
+}

--- a/src/provider/_twitter/types.ts
+++ b/src/provider/_twitter/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared Twitter/X shape primitives used by both `provider/x-profile` and
+ * `provider/x-status`. Anything that overlaps between the FxEmbed profile
+ * timeline API and the single-status API lives here; provider-specific
+ * extensions (retweet metadata, language tag, etc.) stay in each provider.
+ *
+ * Source of truth: https://github.com/FixTweet/FxTwitter/blob/main/README.md
+ * and the public twimg syndication endpoint.
+ */
+
+export interface FxAuthor {
+  screen_name: string
+  name: string
+  id?: string
+  followers?: number
+  following?: number
+  statuses?: number
+  media_count?: number
+  avatar_url?: string
+  banner_url?: string
+  description?: string
+  raw_description?: FxRawText
+  location?: string
+  website?: { url?: string } | null
+  joined?: string
+  protected?: boolean
+}
+
+export interface FxFacet {
+  type: string
+  indices: [number, number]
+  original?: string
+  text?: string
+  display?: string
+  replacement?: string
+  id?: string
+}
+
+export interface FxRawText {
+  text: string
+  display_text_range?: [number, number]
+  facets?: FxFacet[]
+}
+
+export interface FxMediaItem {
+  type: "photo" | "video" | "gif" | string
+  url: string
+  thumbnail_url?: string
+  width?: number
+  height?: number
+}
+
+export interface FxStatus {
+  id: string
+  url: string
+  text: string
+  raw_text?: FxRawText
+  author: FxAuthor
+  created_at: string
+  created_timestamp: number
+  media?: { all?: FxMediaItem[]; photos?: FxMediaItem[]; videos?: FxMediaItem[] }
+  replying_to?: { screen_name: string; status: string } | null
+  reposted_by?: { screen_name: string; name: string } | null
+  quote?: FxStatus
+  community_note?: { text?: string } | string | null
+  lang?: string
+  is_note_tweet?: boolean
+}
+
+// ---------- Normalised cross-provider primitives ----------
+
+export type NormalizedFacet =
+  | { type: "mention"; start: number; end: number; handle: string }
+  | { type: "url"; start: number; end: number; href: string; display: string }
+
+export interface NormalizedMedia {
+  type: "photo" | "video" | "gif"
+  url: string
+}
+
+export interface NormalizedQuote {
+  author: { handle: string; name: string }
+  text: string
+  permalink: string
+}

--- a/src/provider/x-profile/normalize.ts
+++ b/src/provider/x-profile/normalize.ts
@@ -1,14 +1,5 @@
-import type {
-  FxAuthor,
-  FxFacet,
-  FxRawText,
-  FxStatus,
-  NormalizedFacet,
-  NormalizedMedia,
-  NormalizedQuote,
-  NormalizedTweet,
-  ProfileInfo,
-} from "./types"
+import { applyDisplayRange, extractMedia, normalizeQuote } from "../_twitter/normalize"
+import type { FxAuthor, FxStatus, NormalizedTweet, ProfileInfo } from "./types"
 
 export const normalizeProfile = (user: FxAuthor): ProfileInfo => ({
   handle: user.screen_name,
@@ -23,7 +14,7 @@ export const normalizeProfile = (user: FxAuthor): ProfileInfo => ({
 
 export const normalizeStatus = (status: FxStatus): NormalizedTweet => {
   const rt = status.raw_text
-  const { text, facets } = extractDisplayText(rt ?? { text: status.text })
+  const { text, facets } = applyDisplayRange(rt ?? { text: status.text })
   const isRetweet = Boolean(status.reposted_by)
 
   const normalized: NormalizedTweet = {
@@ -49,71 +40,4 @@ export const normalizeStatus = (status: FxStatus): NormalizedTweet => {
   if (status.quote) normalized.quote = normalizeQuote(status.quote)
 
   return normalized
-}
-
-/**
- * Slice rawText by display_text_range and re-index facets into the sliced space.
- * Drops `media` facets (those are t.co placeholders Twitter puts in text).
- *
- * FxEmbed facet indices are UTF-16 code-units (matching JS String semantics),
- * so plain String#slice is correct — this is consistent with how the existing
- * single-tweet extractor (`x-oembed.ts`) treats them.
- */
-const extractDisplayText = (rt: FxRawText): { text: string; facets: NormalizedFacet[] } => {
-  const fullText = rt.text
-  const [rangeStart, rangeEnd] = rt.display_text_range ?? [0, fullText.length]
-  const text = fullText.slice(rangeStart, rangeEnd)
-
-  const facets: NormalizedFacet[] = []
-  for (const facet of rt.facets ?? []) {
-    const normalized = normalizeFacet(facet, rangeStart, rangeEnd)
-    if (normalized) facets.push(normalized)
-  }
-  facets.sort((a, b) => a.start - b.start)
-  return { text, facets }
-}
-
-const normalizeFacet = (facet: FxFacet, rangeStart: number, rangeEnd: number): NormalizedFacet | null => {
-  const [fStart, fEnd] = facet.indices
-  if (fEnd <= rangeStart || fStart >= rangeEnd) return null
-  if (facet.type === "media") return null
-
-  const start = Math.max(0, fStart - rangeStart)
-  const end = Math.min(rangeEnd - rangeStart, fEnd - rangeStart)
-  if (end <= start) return null
-
-  if (facet.type === "mention" && facet.original) {
-    return { type: "mention", start, end, handle: facet.original }
-  }
-  if (facet.type === "url") {
-    // FxEmbed exposes `replacement` as the real destination and `display` as the label.
-    const href = facet.replacement ?? facet.original
-    const display = facet.display ?? href ?? ""
-    if (!href) return null
-    return { type: "url", start, end, href, display }
-  }
-  return null
-}
-
-const extractMedia = (status: FxStatus): NormalizedMedia[] => {
-  const all = status.media?.all ?? []
-  const out: NormalizedMedia[] = []
-  const seen = new Set<string>()
-  for (const m of all) {
-    if (!m.url || seen.has(m.url)) continue
-    seen.add(m.url)
-    const type = m.type === "video" || m.type === "gif" || m.type === "photo" ? m.type : "photo"
-    out.push({ type, url: m.url })
-  }
-  return out
-}
-
-const normalizeQuote = (quote: FxStatus): NormalizedQuote => {
-  const rt = quote.raw_text
-  const { text } = extractDisplayText(rt ?? { text: quote.text })
-  return {
-    author: { handle: quote.author.screen_name, name: quote.author.name },
-    text,
-    permalink: quote.url,
-  }
 }

--- a/src/provider/x-profile/render.ts
+++ b/src/provider/x-profile/render.ts
@@ -1,3 +1,4 @@
+import { escapeMarkdown, formatDate, safeUrl, sanitizeInline } from "../_twitter/render-utils"
 import type { NormalizedFacet, NormalizedQuote, NormalizedTweet, ProfileInfo } from "./types"
 
 interface RenderInput {
@@ -22,7 +23,7 @@ export const renderTimeline = ({ profile, handle, tweets, requested }: RenderInp
 const renderHeader = (profile: ProfileInfo | null, handle: string, got: number, requested: number): string => {
   const lines: string[] = []
   const rawName = profile?.name ?? `@${handle}`
-  const name = sanitizeInlineText(rawName)
+  const name = sanitizeInline(rawName)
   lines.push(`# ${name}`)
   lines.push("")
 
@@ -142,61 +143,6 @@ const applyFacetsMarkdown = (text: string, facets: NormalizedFacet[]): string =>
   if (pos < text.length) out += escapeMarkdown(text.slice(pos))
   return out
 }
-
-/**
- * Validate and sanitize a URL before interpolating it into a markdown link target.
- *
- * Returns `null` for any input that:
- *   - isn't a syntactically valid absolute URL
- *   - uses a protocol other than `http:` or `https:` (blocks `javascript:`, `data:`, etc.)
- *
- * Otherwise returns the URL with `)` and whitespace percent-encoded so the link
- * cannot be terminated early and subsequent bytes cannot leak into the surrounding
- * markdown. This is the single gate every URL from the upstream API must pass
- * through before reaching the output.
- */
-const safeUrl = (raw: string): string | null => {
-  if (!raw) return null
-  let parsed: URL
-  try {
-    parsed = new URL(raw)
-  } catch {
-    return null
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null
-  return parsed.toString().replace(/\)/g, "%29").replace(/\s/g, "%20")
-}
-
-/**
- * Escape characters that would otherwise hijack Markdown rendering.
- * Conservative: only the handful that can break out of a paragraph or a link construct.
- */
-const escapeMarkdown = (s: string): string => s.replace(/([\\`*_[\]])/g, "\\$1")
-
-/**
- * Prepare a free-form string (e.g. display name) for use as inline text in a
- * heading or other single-line position. Drops newlines and leading markdown
- * block markers so an attacker-controlled value cannot open a new block or
- * forge additional structure, then applies the standard inline escape.
- */
-const sanitizeInlineText = (s: string): string => {
-  const flattened = s
-    .replace(/[\r\n]+/g, " ")
-    .replace(/^[\s#>*-]+/, "")
-    .trim()
-  return escapeMarkdown(flattened)
-}
-
-const formatDate = (d: Date): string => {
-  const yyyy = d.getUTCFullYear()
-  const mm = pad(d.getUTCMonth() + 1)
-  const dd = pad(d.getUTCDate())
-  const hh = pad(d.getUTCHours())
-  const mi = pad(d.getUTCMinutes())
-  return `${yyyy}-${mm}-${dd} ${hh}:${mi} UTC`
-}
-
-const pad = (n: number): string => n.toString().padStart(2, "0")
 
 const formatCount = (n: number): string => {
   if (n < 1000) return String(n)

--- a/src/provider/x-profile/types.ts
+++ b/src/provider/x-profile/types.ts
@@ -1,65 +1,8 @@
-// Minimal subset of the FxEmbed API shape we actually consume.
-// Source: https://api.fxtwitter.com/2/profile/<handle>/statuses
-// and https://api.fxtwitter.com/<handle>
+import type { FxAuthor, FxStatus, NormalizedFacet, NormalizedMedia, NormalizedQuote } from "../_twitter/types"
 
-export interface FxAuthor {
-  screen_name: string
-  name: string
-  id?: string
-  followers?: number
-  following?: number
-  statuses?: number
-  media_count?: number
-  avatar_url?: string
-  banner_url?: string
-  description?: string
-  raw_description?: FxRawText
-  location?: string
-  website?: { url?: string } | null
-  joined?: string
-  protected?: boolean
-}
+export type { FxAuthor, FxStatus, NormalizedFacet, NormalizedMedia, NormalizedQuote }
 
-export interface FxFacet {
-  type: string
-  indices: [number, number]
-  original?: string
-  display?: string
-  replacement?: string
-  id?: string
-}
-
-export interface FxRawText {
-  text: string
-  display_text_range?: [number, number]
-  facets?: FxFacet[]
-}
-
-export interface FxMediaItem {
-  type: "photo" | "video" | "gif" | string
-  url: string
-  thumbnail_url?: string
-  width?: number
-  height?: number
-}
-
-export interface FxStatus {
-  id: string
-  url: string
-  text: string
-  raw_text?: FxRawText
-  author: FxAuthor
-  created_at: string
-  created_timestamp: number
-  media?: { all?: FxMediaItem[]; photos?: FxMediaItem[]; videos?: FxMediaItem[] }
-  replying_to?: { screen_name: string; status: string } | null
-  reposted_by?: { screen_name: string; name: string } | null
-  quote?: FxStatus
-  community_note?: { text?: string } | string | null
-  lang?: string
-  is_note_tweet?: boolean
-}
-
+// Profile-API responses (not the single-status ones).
 export interface FxStatusesResponse {
   code: number
   message?: string
@@ -71,23 +14,6 @@ export interface FxProfileResponse {
   code: number
   message?: string
   user?: FxAuthor
-}
-
-// ---------- Normalized internal shape ----------
-
-export interface NormalizedMedia {
-  type: "photo" | "video" | "gif"
-  url: string
-}
-
-export type NormalizedFacet =
-  | { type: "mention"; start: number; end: number; handle: string }
-  | { type: "url"; start: number; end: number; href: string; display: string }
-
-export interface NormalizedQuote {
-  author: { handle: string; name: string }
-  text: string
-  permalink: string
 }
 
 export interface NormalizedTweet {

--- a/src/provider/x-status/__tests__/x-status.test.ts
+++ b/src/provider/x-status/__tests__/x-status.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { parseXStatus } from ".."
+
+const FX_OK = {
+  code: 200,
+  message: "OK",
+  tweet: {
+    id: "123",
+    url: "https://x.com/someone/status/123",
+    text: "hello world",
+    raw_text: {
+      text: "hello @friend https://t.co/abc",
+      display_text_range: [0, 30],
+      facets: [
+        { type: "mention", indices: [6, 13], original: "friend", text: "friend" },
+        { type: "url", indices: [14, 30], replacement: "https://example.com/", display: "example.com" },
+      ],
+    },
+    author: { screen_name: "someone", name: "Some One" },
+    created_at: "2026-04-18T10:11:04.000Z",
+    created_timestamp: Math.floor(new Date("2026-04-18T10:11:04.000Z").getTime() / 1000),
+    lang: "en",
+  },
+}
+
+const SYN_OK = {
+  __typename: "Tweet",
+  id_str: "123",
+  text: "syndication text body",
+  lang: "en",
+  created_at: "2026-04-18T10:11:04.000Z",
+  display_text_range: [0, 21],
+  user: { screen_name: "someone", name: "Some One" },
+}
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } })
+
+interface Handler {
+  (url: string): Response | Promise<Response> | null
+}
+
+const mockFetch = (handlers: Handler[]): { fetch: typeof fetch; calls: string[] } => {
+  const calls: string[] = []
+  const fn = (async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    calls.push(url)
+    for (const h of handlers) {
+      const res = await h(url)
+      if (res) return res
+    }
+    return new Response("not found", { status: 404 })
+  }) as typeof fetch
+  return { fetch: fn, calls }
+}
+
+describe("parseXStatus", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("fetches via fxtwitter as the primary strategy", async () => {
+    const { fetch, calls } = mockFetch([(url) => (url.includes("api.fxtwitter.com") ? jsonResponse(FX_OK) : null)])
+    vi.stubGlobal("fetch", fetch)
+
+    const result = await parseXStatus("https://x.com/someone/status/123")
+
+    expect(result.type).toBe("x-status")
+    expect(result.handle).toBe("someone")
+    expect(result.statusId).toBe("123")
+    expect(result.source).toBe("fxtwitter")
+    expect(result.content).toContain("@friend")
+    expect(result.content).toContain("example.com")
+    expect(calls.some((u) => u.includes("api.fxtwitter.com"))).toBe(true)
+    expect(calls.some((u) => u.includes("syndication"))).toBe(false)
+  })
+
+  it("falls back to syndication when fxtwitter fails", async () => {
+    const { fetch, calls } = mockFetch([
+      (url) => (url.includes("api.fxtwitter.com") ? new Response("boom", { status: 503 }) : null),
+      (url) => (url.includes("syndication.twimg.com") ? jsonResponse(SYN_OK) : null),
+    ])
+    vi.stubGlobal("fetch", fetch)
+
+    const result = await parseXStatus("https://x.com/someone/status/123")
+
+    expect(result.source).toBe("syndication")
+    expect(result.content).toContain("syndication text body")
+    expect(calls.some((u) => u.includes("api.fxtwitter.com"))).toBe(true)
+    expect(calls.some((u) => u.includes("syndication.twimg.com"))).toBe(true)
+  })
+
+  it("throws when every strategy fails", async () => {
+    const { fetch } = mockFetch([() => new Response("nope", { status: 500 })])
+    vi.stubGlobal("fetch", fetch)
+
+    await expect(parseXStatus("https://x.com/someone/status/123")).rejects.toThrow(/fxtwitter.*syndication/)
+  })
+
+  it("handles the /i/status/ form without a handle", async () => {
+    const { fetch } = mockFetch([(url) => (url.includes("api.fxtwitter.com") ? jsonResponse(FX_OK) : null)])
+    vi.stubGlobal("fetch", fetch)
+
+    const result = await parseXStatus("https://x.com/i/status/123")
+    expect(result.type).toBe("x-status")
+    expect(result.statusId).toBe("123")
+  })
+
+  it("rejects invalid status URLs", async () => {
+    await expect(parseXStatus("https://x.com/someone")).rejects.toThrow(/Invalid X status/)
+  })
+})

--- a/src/provider/x-status/fetch-fxtwitter.ts
+++ b/src/provider/x-status/fetch-fxtwitter.ts
@@ -1,0 +1,57 @@
+import { mergeSignals } from "@shared"
+import { applyDisplayRange, extractMedia, normalizeQuote } from "../_twitter/normalize"
+import type { FxStatus } from "../_twitter/types"
+import type { NormalizedStatus } from "./types"
+
+const BASE = "https://api.fxtwitter.com"
+const USER_AGENT = "Mozilla/5.0 (compatible; rdrr/1.0; +https://rdrr.app)"
+const REQUEST_TIMEOUT_MS = 10_000
+
+interface FxResponse {
+  code: number
+  message?: string
+  tweet?: FxStatus
+}
+
+interface FxFetchOptions {
+  signal?: AbortSignal
+  timeoutMs?: number
+  userAgent?: string
+}
+
+export const fetchFromFxtwitter = async (
+  handleOrI: string | null,
+  id: string,
+  opts: FxFetchOptions = {},
+): Promise<NormalizedStatus> => {
+  const base = handleOrI ? `${BASE}/${encodeURIComponent(handleOrI)}/status/${id}` : `${BASE}/status/${id}`
+  const res = await fetch(base, {
+    headers: { "User-Agent": opts.userAgent ?? USER_AGENT },
+    signal: mergeSignals(opts.timeoutMs ?? REQUEST_TIMEOUT_MS, opts.signal),
+  })
+  if (!res.ok) throw new Error(`fxtwitter ${res.status} ${res.statusText}`)
+  const body = (await res.json()) as FxResponse
+  if (body.code !== 200 || !body.tweet) throw new Error(`fxtwitter: ${body.message ?? "no tweet"}`)
+  return toNormalized(body.tweet)
+}
+
+const toNormalized = (tweet: FxStatus): NormalizedStatus => {
+  const { text, facets } = applyDisplayRange(tweet.raw_text ?? { text: tweet.text })
+  const createdAt = tweet.created_timestamp
+    ? new Date(tweet.created_timestamp * 1000)
+    : tweet.created_at
+      ? new Date(tweet.created_at)
+      : new Date(0)
+  return {
+    id: tweet.id,
+    permalink: tweet.url,
+    createdAt,
+    author: { handle: tweet.author.screen_name, name: tweet.author.name },
+    text,
+    facets,
+    media: extractMedia(tweet),
+    replyTo: tweet.replying_to ? { handle: tweet.replying_to.screen_name } : null,
+    quote: tweet.quote ? normalizeQuote(tweet.quote) : null,
+    lang: tweet.lang,
+  }
+}

--- a/src/provider/x-status/fetch-syndication.ts
+++ b/src/provider/x-status/fetch-syndication.ts
@@ -1,0 +1,148 @@
+import { mergeSignals } from "@shared"
+import type { NormalizedFacet, NormalizedMedia, NormalizedQuote, NormalizedStatus } from "./types"
+
+const BASE = "https://cdn.syndication.twimg.com/tweet-result"
+const USER_AGENT = "Mozilla/5.0 (compatible; rdrr/1.0; +https://rdrr.app)"
+const REQUEST_TIMEOUT_MS = 10_000
+
+// X's syndication endpoint requires a `token` query parameter but currently
+// accepts any non-empty string. Sending a short fixed token is honest about
+// that: if Twitter ever tightens validation we'll switch to a real
+// widget-derived token, but reverse-engineering their algorithm now would
+// just be cargo-culting for no runtime benefit.
+const SYNDICATION_TOKEN = "a"
+
+interface SynUser {
+  screen_name: string
+  name: string
+}
+
+interface SynMentionEntity {
+  screen_name: string
+  indices: [number, number]
+}
+
+interface SynUrlEntity {
+  url: string
+  expanded_url: string
+  display_url: string
+  indices: [number, number]
+}
+
+interface SynMediaEntity {
+  type: string
+  media_url_https: string
+  video_info?: { variants?: Array<{ url: string; content_type?: string; bitrate?: number }> }
+  indices: [number, number]
+}
+
+interface SynTweet {
+  __typename?: string
+  id_str: string
+  text: string
+  lang?: string
+  created_at: string
+  display_text_range?: [number, number]
+  user: SynUser
+  in_reply_to_screen_name?: string | null
+  entities?: {
+    user_mentions?: SynMentionEntity[]
+    urls?: SynUrlEntity[]
+    media?: SynMediaEntity[]
+  }
+  mediaDetails?: SynMediaEntity[]
+  quoted_tweet?: SynTweet
+  tombstone?: { text?: { text?: string } }
+}
+
+interface SynFetchOptions {
+  signal?: AbortSignal
+  timeoutMs?: number
+  userAgent?: string
+}
+
+export const fetchFromSyndication = async (id: string, opts: SynFetchOptions = {}): Promise<NormalizedStatus> => {
+  const url = `${BASE}?id=${encodeURIComponent(id)}&token=${SYNDICATION_TOKEN}&lang=en`
+  const res = await fetch(url, {
+    headers: { "User-Agent": opts.userAgent ?? USER_AGENT, Accept: "application/json" },
+    signal: mergeSignals(opts.timeoutMs ?? REQUEST_TIMEOUT_MS, opts.signal),
+  })
+  if (!res.ok) throw new Error(`syndication ${res.status} ${res.statusText}`)
+  const body = (await res.json()) as SynTweet
+  if (body.tombstone?.text?.text) throw new Error(`syndication: ${body.tombstone.text.text}`)
+  if (!body.id_str || !body.user) throw new Error("syndication: incomplete response")
+  return toNormalized(body)
+}
+
+const toNormalized = (tweet: SynTweet): NormalizedStatus => {
+  const [rangeStart, rangeEnd] = tweet.display_text_range ?? [0, tweet.text.length]
+  const text = tweet.text.slice(rangeStart, rangeEnd)
+  const facets = buildFacets(tweet, rangeStart, rangeEnd)
+
+  return {
+    id: tweet.id_str,
+    permalink: `https://x.com/${tweet.user.screen_name}/status/${tweet.id_str}`,
+    createdAt: new Date(tweet.created_at),
+    author: { handle: tweet.user.screen_name, name: tweet.user.name },
+    text,
+    facets,
+    media: extractMedia(tweet),
+    replyTo: tweet.in_reply_to_screen_name ? { handle: tweet.in_reply_to_screen_name } : null,
+    quote: tweet.quoted_tweet ? toQuote(tweet.quoted_tweet) : null,
+    lang: tweet.lang,
+  }
+}
+
+const toQuote = (q: SynTweet): NormalizedQuote => {
+  const [rs, re] = q.display_text_range ?? [0, q.text.length]
+  return {
+    author: { handle: q.user.screen_name, name: q.user.name },
+    text: q.text.slice(rs, re),
+    permalink: `https://x.com/${q.user.screen_name}/status/${q.id_str}`,
+  }
+}
+
+const buildFacets = (tweet: SynTweet, rangeStart: number, rangeEnd: number): NormalizedFacet[] => {
+  const facets: NormalizedFacet[] = []
+  const reindex = (fs: number, fe: number): [number, number] | null => {
+    if (fe <= rangeStart || fs >= rangeEnd) return null
+    return [Math.max(0, fs - rangeStart), Math.min(rangeEnd - rangeStart, fe - rangeStart)]
+  }
+
+  for (const m of tweet.entities?.user_mentions ?? []) {
+    const r = reindex(m.indices[0], m.indices[1])
+    if (!r || r[1] <= r[0]) continue
+    facets.push({ type: "mention", start: r[0], end: r[1], handle: m.screen_name })
+  }
+  for (const u of tweet.entities?.urls ?? []) {
+    const r = reindex(u.indices[0], u.indices[1])
+    if (!r || r[1] <= r[0] || !u.expanded_url) continue
+    facets.push({ type: "url", start: r[0], end: r[1], href: u.expanded_url, display: u.display_url || u.expanded_url })
+  }
+  facets.sort((a, b) => a.start - b.start)
+  return facets
+}
+
+const extractMedia = (tweet: SynTweet): NormalizedMedia[] => {
+  const out: NormalizedMedia[] = []
+  const seen = new Set<string>()
+  const items = tweet.mediaDetails ?? tweet.entities?.media ?? []
+  for (const m of items) {
+    if (m.type === "video" || m.type === "animated_gif") {
+      const variants = m.video_info?.variants ?? []
+      const mp4 = variants
+        .filter((v) => v.content_type === "video/mp4")
+        .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0))[0]
+      const url = mp4?.url ?? m.media_url_https
+      if (!url || seen.has(url)) continue
+      seen.add(url)
+      out.push({ type: m.type === "animated_gif" ? "gif" : "video", url })
+    } else {
+      const url = m.media_url_https
+      if (!url || seen.has(url)) continue
+      seen.add(url)
+      out.push({ type: "photo", url })
+    }
+  }
+  return out
+}

--- a/src/provider/x-status/fetch.ts
+++ b/src/provider/x-status/fetch.ts
@@ -1,0 +1,43 @@
+import { fetchFromFxtwitter } from "./fetch-fxtwitter"
+import { fetchFromSyndication } from "./fetch-syndication"
+import type { FetchOutcome } from "./types"
+
+interface FetchStatusOptions {
+  signal?: AbortSignal
+  timeoutMs?: number
+  userAgent?: string
+}
+
+/**
+ * Resolve a single tweet via an ordered list of strategies; first success wins.
+ *
+ * Strategy ordering rationale:
+ *   1. fxtwitter — richer payload (article mode, raw facets, full quotes) and
+ *      survives Twitter rate limits via a separate infrastructure.
+ *   2. syndication — Twitter's own `cdn.syndication.twimg.com` endpoint used by
+ *      the embed widget. Thinner data but almost always reachable, so it's the
+ *      safety net when fxtwitter is down or rate-limited.
+ */
+export const fetchStatus = async (
+  handle: string | null,
+  id: string,
+  opts: FetchStatusOptions = {},
+): Promise<FetchOutcome> => {
+  const errors: string[] = []
+
+  try {
+    const status = await fetchFromFxtwitter(handle, id, opts)
+    return { status, source: "fxtwitter" }
+  } catch (err) {
+    errors.push(`fxtwitter: ${(err as Error).message}`)
+  }
+
+  try {
+    const status = await fetchFromSyndication(id, opts)
+    return { status, source: "syndication" }
+  } catch (err) {
+    errors.push(`syndication: ${(err as Error).message}`)
+  }
+
+  throw new Error(`Could not fetch tweet ${id} — ${errors.join("; ")}`)
+}

--- a/src/provider/x-status/index.ts
+++ b/src/provider/x-status/index.ts
@@ -1,0 +1,38 @@
+import { countWords, estimateReadTime } from "@shared"
+import type { ParseOptions, XStatusResult } from "../../types"
+import { extractXStatus } from "../../detect"
+import { fetchStatus } from "./fetch"
+import { renderStatus } from "./render"
+
+export const parseXStatus = async (url: string, options?: ParseOptions): Promise<XStatusResult> => {
+  const ref = extractXStatus(url)
+  if (!ref) throw new Error(`Invalid X status URL: ${url}`)
+
+  const { status, source } = await fetchStatus(ref.handle, ref.id, {
+    signal: options?.signal,
+    timeoutMs: options?.timeoutMs,
+    userAgent: options?.userAgent,
+  })
+
+  const content = renderStatus(status)
+  const wordCount = countWords(content)
+  const title = `${status.author.name} (@${status.author.handle})`.trim()
+  const description = status.text.replace(/\s+/g, " ").trim().slice(0, 200)
+
+  return {
+    type: "x-status",
+    title,
+    author: `@${status.author.handle}`,
+    content,
+    description,
+    domain: "x.com",
+    siteName: "X (Twitter)",
+    language: status.lang,
+    published: status.createdAt.toISOString().slice(0, 10),
+    wordCount,
+    readTime: estimateReadTime(wordCount, options?.wordsPerMinute),
+    handle: status.author.handle,
+    statusId: status.id,
+    source,
+  }
+}

--- a/src/provider/x-status/render.ts
+++ b/src/provider/x-status/render.ts
@@ -1,0 +1,76 @@
+import { escapeMarkdown, formatDate, safeUrl, sanitizeInline } from "../_twitter/render-utils"
+import type { NormalizedFacet, NormalizedQuote, NormalizedStatus } from "./types"
+
+export const renderStatus = (status: NormalizedStatus): string => {
+  const lines: string[] = []
+  const permalink = safeUrl(status.permalink)
+  const dateLabel = formatDate(status.createdAt)
+
+  lines.push(`# ${sanitizeInline(status.author.name)} (@${status.author.handle})`)
+  lines.push("")
+  lines.push(permalink ? `_[${dateLabel}](${permalink})_` : `_${dateLabel}_`)
+
+  if (status.replyTo) {
+    lines.push("")
+    lines.push(`↪ Reply to @${status.replyTo.handle}`)
+  }
+
+  const body = applyFacets(status.text, status.facets)
+  if (body.trim()) {
+    lines.push("")
+    lines.push(body)
+  }
+
+  if (status.quote) {
+    lines.push("")
+    lines.push(renderQuote(status.quote))
+  }
+
+  if (status.media.length > 0) {
+    lines.push("")
+    for (const m of status.media) {
+      const url = safeUrl(m.url)
+      if (!url) continue
+      if (m.type === "video" || m.type === "gif") lines.push(`[${m.type}](${url})`)
+      else lines.push(`![](${url})`)
+    }
+  }
+
+  return lines.join("\n").trimEnd() + "\n"
+}
+
+const renderQuote = (quote: NormalizedQuote): string => {
+  const permalink = safeUrl(quote.permalink)
+  const label = `@${quote.author.handle}`
+  const head = permalink ? `> **Quoting [${label}](${permalink})**` : `> **Quoting ${label}**`
+  const out = [head]
+  const body = quote.text.trim()
+  if (body) {
+    out.push(">")
+    for (const line of body.split("\n")) out.push(`> ${escapeMarkdown(line)}`)
+  }
+  return out.join("\n")
+}
+
+const applyFacets = (text: string, facets: NormalizedFacet[]): string => {
+  if (facets.length === 0) return escapeMarkdown(text)
+
+  let out = ""
+  let pos = 0
+  for (const f of facets) {
+    if (f.start < pos) continue
+    if (f.start > pos) out += escapeMarkdown(text.slice(pos, f.start))
+    const slice = text.slice(f.start, f.end)
+    if (f.type === "mention") {
+      out += `[${escapeMarkdown(slice)}](https://x.com/${f.handle})`
+    } else {
+      const href = safeUrl(f.href)
+      const label = f.display || slice
+      out += href ? `[${escapeMarkdown(label)}](${href})` : escapeMarkdown(label)
+    }
+    pos = f.end
+  }
+  if (pos < text.length) out += escapeMarkdown(text.slice(pos))
+  return out
+}
+

--- a/src/provider/x-status/types.ts
+++ b/src/provider/x-status/types.ts
@@ -1,0 +1,29 @@
+import type { NormalizedFacet, NormalizedMedia, NormalizedQuote } from "../_twitter/types"
+
+export type { NormalizedFacet, NormalizedMedia, NormalizedQuote }
+
+/**
+ * Shape we normalise upstream single-tweet responses into.
+ *
+ * Both the fxtwitter API and the public twimg syndication endpoint can produce
+ * this; providers should populate what they know and leave the rest.
+ */
+export interface NormalizedStatus {
+  id: string
+  permalink: string
+  createdAt: Date
+  author: { handle: string; name: string }
+  text: string
+  /** Inline mention/url facets, sorted by start offset. */
+  facets: NormalizedFacet[]
+  media: NormalizedMedia[]
+  replyTo?: { handle: string } | null
+  quote?: NormalizedQuote | null
+  lang?: string
+}
+
+export interface FetchOutcome {
+  status: NormalizedStatus
+  /** Strategy name — surfaces in the result for debugging/agents. */
+  source: string
+}

--- a/src/rdrr.ts
+++ b/src/rdrr.ts
@@ -48,6 +48,10 @@ const route = async (
       const { parseXProfile } = await import("./provider/x-profile")
       return parseXProfile(url, options)
     }
+    case "x-status": {
+      const { parseXStatus } = await import("./provider/x-status")
+      return parseXStatus(url, options)
+    }
     case "webpage": {
       const { parseWeb } = await import("./provider/web")
       return parseWeb(url, options)

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -15,8 +15,12 @@ export const safeDomain = (url: string): string => {
   }
 }
 
-export const ensureProtocol = (url: string): string =>
-  url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`
+// Any scheme-like prefix (`foo://`, `ftp:`, `mailto:`, etc.) — if one is already
+// present we must leave it alone so `isValidUrl` can reject non-HTTP schemes
+// cleanly instead of producing a Frankenstein `https://ftp://...`.
+const SCHEME_PREFIX = /^[a-z][a-z0-9+\-.]*:/i
+
+export const ensureProtocol = (url: string): string => (SCHEME_PREFIX.test(url) ? url : `https://${url}`)
 
 export const formatTime = (seconds: number): string => {
   const h = Math.floor(seconds / 3600)

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface ParseOptions {
 }
 
 export interface ParseResult {
-  type: "youtube" | "webpage" | "github" | "pdf" | "x-profile"
+  type: "youtube" | "webpage" | "github" | "pdf" | "x-profile" | "x-status"
   title: string
   author: string
   content: string
@@ -81,4 +81,12 @@ export interface XProfileResult extends ParseResult {
   type: "x-profile"
   handle: string
   postCount: number
+}
+
+export interface XStatusResult extends ParseResult {
+  type: "x-status"
+  handle: string
+  statusId: string
+  /** Which upstream strategy produced the result (e.g. "fxtwitter", "syndication"). */
+  source: string
 }


### PR DESCRIPTION
## Summary

The "make rdrr a first-class tool for AI agents" release.

- **Single X posts** via fxtwitter primary + twimg syndication fallback (bypasses x.com login wall)
- **`--budget <tokens>`** — paragraph-boundary truncation, fence-aware, preserves head
- **`--quality`** — readability score 0-100 with signals (5 languages)
- **`--format md|json|jsonl|xml`** — unified output; XML has `<?xml?>` decl + CDATA-safe
- **`-c, --clip`** — cross-platform clipboard
- **`rdrr history` / `rdrr last`** — local JSONL log with sensitive-arg redaction

### Critical fix

Site extractors (reddit, hackernews, substack, chatgpt, claude, grok, gemini, github, x-oembed, x-article, c2-wiki, bbcode-data) were tree-shaken out of the published bundle. `sideEffects` whitelist didn't cover source site-init modules. Restored.

### Fxtwitter dedup

Shared types + normalizer now live in `src/provider/_twitter/`; x-profile and x-status both consume. Render utils (`safeUrl`, `escapeMarkdown`, `formatDate`, `sanitizeInline`) also consolidated.

### Security

- URL basic-auth stripped
- Query params `api_key`/`token`/`authorization`/`secret` redacted
- `--github-token` / `--user-agent` values redacted in history
- Budget never emits an unclosed fence
- XML CDATA splits stray `]]>` in article content
- Empty/malformed stdin no longer crashes parseLinkedomHTML

### Engine refactor

`extract.ts` decomposed: single `finaliseMarkdown` exit per function, named retry helpers (`retryWithHiddenIncluded`, `retryWithLowScoringKept`, `bestOfAttempts`, `rescueFromSchemaOrg`), shared `buildResultFromExtractor`.

## Test plan

- [x] pnpm lint (0/0)
- [x] pnpm build (1.90 MB, 34 files)
- [x] pnpm test (217/217)
- [x] pnpm install --frozen-lockfile
- [x] Live CLI smoke: react.dev/learn, rdrr.app/docs, x.com/.../status/...
- [x] Downstream: @rdrr/api 128/128 + typecheck, @rdrr/web build + 22/22
- [x] QA audit — 50+ edge scenarios, 5 critical fixes landed